### PR TITLE
Fix loading of printer/parser from package.json

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@
 import {program} from "commander"
 import console from "node:console"
 import process from "node:process"
+import {fileURLToPath,URL} from "node:url"
 
 import BeDoc, {Environment} from "./core/Core.js"
 import {ConfigurationParameters} from "./core/ConfigurationParameters.js"
@@ -10,18 +11,21 @@ import {ConfigurationParameters} from "./core/ConfigurationParameters.js"
 import * as ActionUtil from "./core/util/ActionUtil.js"
 import * as FDUtil from "./core/util/FDUtil.js"
 
-const {loadPackageJson} = ActionUtil
-const {resolveDirectory} = FDUtil
+const {loadJson} = ActionUtil
+const {resolveFilename,resolveDirectory} = FDUtil
 
 // Main entry point
 ;(async() => {
   try {
     // Get package info
     const basePath = resolveDirectory(process.cwd())
-    const packageJson = loadPackageJson(basePath)
+    const thisPath = resolveDirectory(fileURLToPath(new URL("..", import.meta.url)))
+    const bedocPackageJson = loadJson(resolveFilename("package.json", thisPath))
 
     // Setup program
-    program.name(packageJson.name).description(packageJson.description)
+    program
+      .name(bedocPackageJson.name)
+      .description(bedocPackageJson.description)
 
     // Build CLI
     for(const [name, parameter] of Object.entries(ConfigurationParameters)) {
@@ -42,7 +46,7 @@ const {resolveDirectory} = FDUtil
 
     // Add version option last
     program.version(
-      packageJson.version,
+      bedocPackageJson.version,
       "-v, --version",
       "Output the version number",
     )
@@ -68,7 +72,6 @@ const {resolveDirectory} = FDUtil
         options: {
           ...optionsWithSources,
           basePath: {value: basePath, source: "cli"},
-          packageJson: {value: packageJson, source: "cli"},
         },
         source: Environment.CLI
       })

--- a/src/core/Discovery.js
+++ b/src/core/Discovery.js
@@ -40,7 +40,7 @@ export default class Discovery {
     const options = this.core.options ?? {}
 
     if(options?.mockPath) {
-      debug("Discovering mock actions in `%s`", 1, options.mockPath)
+      debug("Discovering mock actions in `%s`", 2, options.mockPath)
 
       bucket.push(
         ...(await getFiles([
@@ -49,7 +49,7 @@ export default class Discovery {
         ])),
       )
     } else {
-      debug("Mock path not set, discovering actions in node_modules", 1)
+      debug("Mock path not set, discovering actions in node_modules", 2)
 
       debug("Looking for actions in project's package.json", 2)
       if(this.core.packageJson?.modules) {


### PR DESCRIPTION
Ensure the package.json is correctly loaded in the Core.js constructor, allowing the bedoc CLI to access the specified printer and parser. This addresses the issue of the parser and printer not being found during execution. Fixes #162