### PR TITLE
Massive upgrade to configuration and hooks!

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/bedoc",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Pluggable documentation engine for any language and format",
   "publisher": "gesslar",
   "author": "gesslar",

--- a/src/core/ActionManager.js
+++ b/src/core/ActionManager.js
@@ -7,10 +7,12 @@ export default class ActionManager {
   #log
   #debug
   #file
+  #variables
 
-  constructor(actionDefinition, logger) {
+  constructor({actionDefinition, logger, variables}) {
     this.#log = logger
     this.#debug = this.#log.newDebug()
+    this.#variables = variables
 
     this.#initialize(actionDefinition)
   }
@@ -65,6 +67,10 @@ export default class ActionManager {
     return this.#log
   }
 
+  get variables() {
+    return this.#variables
+  }
+
   async #setupAction() {
     const setup = this.action?.setup
 
@@ -90,7 +96,11 @@ export default class ActionManager {
       return
 
     await this.hookManager.setup.call(
-      this.hookManager.hooks, {parent: this.action, log: this.#log}
+      this.hookManager.hooks, {
+        action: this.action,
+        variables: this.#variables,
+        log: this.#log
+      }
     )
   }
 

--- a/src/core/ConfigurationParameters.js
+++ b/src/core/ConfigurationParameters.js
@@ -120,6 +120,14 @@ const ConfigurationParameters = Object.freeze({
       mustExist: true,
     },
   },
+  sub: {
+    short: "s",
+    param: "name",
+    description: "Specify a subconfiguration",
+    type: newTypeSpec("string"),
+    required: false,
+    dependent: "config",
+  },
   debug: {
     short: "d",
     description: "Enable debug mode",

--- a/src/core/Core.js
+++ b/src/core/Core.js
@@ -91,14 +91,18 @@ export default class Core {
 
     // Adding to instance
     instance.actions = {}
+    const {variables} = validConfig
     const managers = {print: PrintManager, parse: ParseManager}
-    for(const [, value] of Object.entries(finalActions)) {
-      const {action: actionType} = value.action.meta
+    for(const [, actionDefinition] of Object.entries(finalActions)) {
+      const {action: actionType} = actionDefinition.action.meta
 
       debug("Attaching %o action to instance", 2, actionType)
-      instance.actions[actionType] = new managers[actionType](
-        value, instance.logger
-      )
+      instance.actions[actionType] =
+        new managers[actionType] ({
+          actionDefinition,
+          logger: instance.logger,
+          variables
+        })
 
       if(validConfig.hooks) {
         const hookManager = await HookManager.new({

--- a/src/core/Discovery.js
+++ b/src/core/Discovery.js
@@ -225,7 +225,7 @@ export default class Discovery {
           JSON.stringify(moduleFile, null, 2) + "\n" +
           JSON.stringify(action, null, 2))
 
-      debug("Checking action `%s`", 2, metaAction)
+      debug("Checking action %o", 2, metaAction)
 
       const isValid = this.#validMeta(metaAction, {action, contract})
 
@@ -246,7 +246,7 @@ export default class Discovery {
 
     for(const actionType of actionTypes) {
       const total = resultActions[actionType].length
-      debug("Found %o `%o` actions", 2, total, actionType)
+      debug("Found %o %o actions", 2, total, actionType)
     }
 
     const total = Object.keys(resultActions).reduce((acc, curr) => {
@@ -280,7 +280,7 @@ export default class Discovery {
 
       // First let's check if we wanted something specific
       if(validatedConfig[config]) {
-        debug("Checking for specific `%s` action", 3, actionType)
+        debug("Checking for specific %o action", 3, actionType)
         const found = actions[actionType].find(
           a => a.file.specificType.includes(actionType)
         )
@@ -294,7 +294,7 @@ export default class Discovery {
       }
 
       // Hmm! We didn't find anything specific. Let's check the criterion
-      debug("Checking for `%s` actions with criterion `%s`", 3, actionType, criterion)
+      debug("Checking for %o actions with criterion %o", 3, actionType, criterion)
       debug("Validated config to check against: %o", 3, validatedConfig)
       const found = actions[actionType].filter(a => {
         debug("Meta criterion value: %o", 4, a.action.meta[criterion])
@@ -341,7 +341,7 @@ export default class Discovery {
    */
   #validMeta(actionType, toValidate) {
     const debug = this.#debug
-    debug("Checking meta requirements for `%s`", 3, actionType)
+    debug("Checking meta requirements for %o", 3, actionType)
 
     const requirements = actionMetaRequirements[actionType]
     if(!requirements)


### PR DESCRIPTION
Configuration

You can now, in a configuration file, have multiple configurations called subconfigurations.

An example configuration file might look like this:
```json5
{
  debugLevel: 0,
  sub:
  [
    {
      name: "devwiki",
      // This will override the debugLevel from the main config
      debugLevel: 2,
      parser: "src/actions/bedoc-lpcdocs-parser.js",
      printer: "src/actions/bedoc-wikitext-printer.js",
      input: ["/frogdice/thresh/lib/adm/simul_efun/*.c"],
      hooks: "src/hooks/lpc-wikitext-hooks-with-upload.js",
      variables: {
        // Environment variables for wiki uploads
        env: {
          BASE_URL: "DEVWIKI_BASE_URL",
          BOT_USERNAME: "DEVWIKI_USERNAME",
          BOT_PASSWORD: "DEVWIKI_PASSWORD",
        }
      }
    },
    {
      // This sub will fail because it has no actions defined.
      name: "helpwiki",
      input: ["/frogdice/thresh/lib/doc/help/*.help"],
      variables: {
        env: {
          baseUrl: "HELPWIKI_BASE_URL",
          userName: "HELPWIKI_USERNAME",
          password: "HELPWIKI_PASSWORD",
        }
      }
    },
  ]
}
```

Hooks

When you specify you config file in any of your `package.json`, environment variables, or via the `-c` CLI parameter, you can also specify `-s`, which will be the name of the subconfiguration that will override the values of the main configuration file.

Also, variables are sent to hooks in the `setup` method.

Example:
```
/**
  * Setup the current hooks and set some initial values.
  *
  * @async
  * @function
  * @param {object} options Passed in options object
  * @param {object} options.action The print action
  * @param {Logger} options.log An instance of the Logger class
  * @param {object} options.variables Any variables that have been passed from config
  */
async setup({log,variables}) {
  try {
    this.log = log
    this.debug = log.newDebug()

    const {env: envVarNames} = variables

    for(const [key, value] of Object.entries(envVarNames || {}))
      this[key] = process.env[value]

    this.log.debug("Init hooks for: %o", 2, this)
  } catch(error) {
    this.log.error(`Error setting up hooks:`, error)
  }
    }
```

Th-th-th-th-that's all folks. For this update, anyway.