### PR TITLE
Update GitHub Actions to use GITHUB_TOKEN for write access

### DIFF
--- a/.github/workflows/rebase-base-into-pr.yml
+++ b/.github/workflows/rebase-base-into-pr.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.PAT_TOKEN }}  # Use a PAT for write access
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rebase base branch into PR branch
         run: |


### PR DESCRIPTION
Switch from using PAT_TOKEN to GITHUB_TOKEN for write access in the GitHub Actions workflow.

Fixes #193