### PR TITLE
Add chokidar-as-cli example and implement Lua library functions

### DIFF
--- a/examples/chokidar-as-cli/src/data.c
+++ b/examples/chokidar-as-cli/src/data.c
@@ -16,7 +16,6 @@ varargs mixed data_value(string file, string key, mixed def) {}
  * @param {string} file The file to write to.
  * @param {string} key The key to write.
  * @param {mixed} data The value(s) to write.
- * @return {void}
  */
 varargs void data_write(string file, string key, mixed data...) {}
 

--- a/examples/chokidar-as-cli/src/function.c
+++ b/examples/chokidar-as-cli/src/function.c
@@ -1,0 +1,82 @@
+/**
+ * Checks if a given function is valid and not owned by a destructed
+ * object.
+ *
+ * @param {mixed} f The function to check.
+ * @return {int} 1 if the function is valid, otherwise 0.
+ */
+int valid_function(mixed f) {}
+
+/**
+ * Returns a formatted string of the current call stack trace.
+ *
+ * @param {int} colour Whether to include colour codes (optional, default: 0)
+ * @return {string} The formatted call stack trace.
+ */
+varargs string call_trace(int colour) {}
+
+/**
+ * Assembles a callback function from the provided arguments.
+ * This function is used to create a callable structure that can be
+ * invoked later. The callback can be either a method on an object or
+ * a function.
+ *
+ * Usage:
+ * When you need to create a callback for an object method:
+ *   `assemble_call_back(object, "method", args...)`
+ * When you need to create a callback for a function:
+ *   `assemble_call_back(function, args...)`
+ *
+ * The function performs the following steps:
+ * 1. Checks if the provided arguments form a valid array
+ * 2. Determines the size of the arguments array
+ * 3. Checks if the first argument is an object. If so, it verifies that
+ *    the second argument is a valid method name on the object
+ * 4. If the first argument is a function, it creates a callback with the
+ *    function and any additional arguments
+ * 5. Returns the assembled callback as an array
+ *
+ * @param {mixed} arg The arguments to assemble into a callback.
+ * @return {mixed*} The assembled callback.
+ */
+mixed *assemble_call_back(mixed arg...) {}
+
+/**
+ * Executes a callback with the given arguments.
+ *
+ * @param {mixed} cb The callback to execute.
+ * @param {mixed} new_arg The arguments to pass to the callback (optional).
+ * @return {mixed} The result of the callback execution.
+ */
+mixed call_back(mixed cb, mixed new_arg...) {}
+
+/**
+ * Calls the specified function on the given object if it exists.
+ *
+ * @param {mixed} ob The object to call the function on.
+ * @param {string} func The name of the function to call.
+ * @param {mixed} arg The argument to pass to the function (optional).
+ * @return {mixed} The return value of the function, or null if the function
+ *                   does not exist.
+ */
+varargs mixed call_if(mixed ob, string func, mixed arg...) {}
+
+/**
+ * Delays an action for a specified amount of time.
+ *
+ * @param {string} action The action to delay.
+ * @param {float} delay The amount of time to delay the action.
+ * @param {mixed*} cb The callback to execute after the delay.
+ * @return {int} The ID of the delayed action.
+ */
+varargs int delay_act(string act, float delay, mixed *cb) {}
+
+/**
+ * Asserts that a statement is true. If the statement is false, it
+ * will throw an error with the given message. If no message is
+ * provided, it will use a default message.
+ *
+ * @param {mixed} statement The statement to assert.
+ * @param {string} message The message to display if the condition is false (optional).
+ */
+varargs void assert(mixed statement, string message) {}

--- a/examples/chokidar-as-cli/src/numbers.c
+++ b/examples/chokidar-as-cli/src/numbers.c
@@ -1,0 +1,99 @@
+#include <simul_efun.h>
+
+/**
+ * Calculates what `a` percent of `b` is.
+ *
+ * @param {float} a The percentage value.
+ * @param {float} b The whole value.
+ * @return {float} The value that is `a` percent of `b`.
+ */
+float percent_of(float a, float b) {}
+
+/**
+ * Calculates what percentage `a` is of `b`.
+ *
+ * @param {float} a The part value.
+ * @param {float} b The whole value.
+ * @return {float} The percentage of `a` out of `b`.
+ */
+float percent(float a, float b) {}
+
+/**
+ * Ensures a value is within a specified range.
+ *
+ * @param {float} min The minimum value.
+ * @param {float} max The maximum value.
+ * @param {float} val The value to check.
+ * @return {float} The value, constrained within the range of `min` to `max`.
+ */
+float clamp(float min, float max, float val) {}
+
+/**
+ * Calculates the remainder of `a` divided by `b`. If either value is an integer,
+ * it will be converted to float before calculation.
+ *
+ * @param {mixed} a The dividend.
+ * @param {mixed} b The divisor.
+ * @return {float} The remainder of `a` divided by `b`.
+ */
+varargs float remainder(mixed a, mixed b) {}
+
+/**
+ * Calculates the sum of all elements in an array.
+ *
+ * @param {mixed*} arr The array of numbers to sum.
+ * @return {int} The sum of all elements in the array.
+ */
+int sum(mixed *arr) {}
+
+/**
+ * Evaluates a number against a condition. The condition can be a
+ * simple comparison, or a compound condition using `AND` and `OR`.
+ * This system allows for the evaluation of numeric conditions
+ * using a specific set of operators and syntax rules.
+ *
+ * Basic Operators:
+ * `<` Less than
+ * `>` Greater than
+ * `<=` Less than or equal to
+ * `>=` Greater than or equal to
+ * `=` or `==` Equal to
+ * `!=` Not equal to
+ * `%` Checks if a number is divisible by the given value
+ *
+ * Range Operator:
+ * Use a hyphen (`-`) to specify a range, inclusive of both ends.
+ * Example: `5-15` means any number from `5` to `15`, including
+ * `5` and `15`.
+ *
+ * Set Inclusion/Exclusion:
+ * `[a,b,c]` Checks if a number is one of the listed values
+ * `![a,b,c]` Checks if a number is not one of the listed values
+ *
+ * Logical Operators:
+ * `AND` Both conditions must be true
+ * `OR` At least one condition must be true
+ *
+ * Grouping:
+ * Use parentheses `()` to group conditions and override default precedence.
+ *
+ * Precedence (from highest to lowest):
+ * 1. Parentheses `()`
+ * 2. Basic operators, Range, Modulo, Set inclusion/exclusion
+ * 3. `AND`
+ * 4. `OR`
+ *
+ * Syntax Rules:
+ * No spaces are allowed in the condition string
+ * Operators must be used exactly as specified
+ * Set values must be comma-separated without spaces
+ *
+ * Example: `(5-15AND%3)OR[20,25,30]`
+ * This checks if a number is between `5` and `15` (inclusive) AND
+ * divisible by `3`, OR if it's `20`, `25`, or `30`.
+ *
+ * @param {int} number The number to evaluate.
+ * @param {string} condition The condition to evaluate against.
+ * @return {int} 1 if the condition evaluates to true, 0 otherwise.
+ */
+int evaluate_number(int number, string condition) {}

--- a/examples/chokidar-as-cli/src/string.c
+++ b/examples/chokidar-as-cli/src/string.c
@@ -1,0 +1,169 @@
+/**
+ * Appends a string to another string if it is not already there. If the string
+ * is already present, the original string is returned.
+ *
+ * @param {string} source The string to append to.
+ * @param {string} to_append The string to append.
+ * @return {string} The original string with the appended string if it was not
+ *                    already present.
+ */
+string append(string source, string to_append) {}
+
+/**
+ * Prepends a string to another string if it is not already there.
+ * If the string is already present, the original string is returned.
+ *
+ * @param {string} source The string to prepend to.
+ * @param {string} to_prepend The string to prepend.
+ * @return {string} The original string with the prepended string if it was not
+ *                    already present.
+ */
+string prepend(string source, string to_prepend) {}
+
+/**
+ * Chops a substring off the end or beginning of another string if
+ * it is present. If the substring is not present, the original
+ * string is returned. If no direction is specified, chops from
+ * the right (-1).
+ *
+ * @param {string} str The string to chop from.
+ * @param {string} sub The substring to chop.
+ * @param {int} dir The direction to chop: 1 for left, -1 for right (optional, default: -1)
+ * @return {string} The string with the substring chopped off if it was present.
+ */
+varargs string chop(string str, string sub, int dir) {}
+
+/**
+ * Extracts a substring from a string. If no ending position is provided,
+ * extracts from the starting position to the end of the string.
+ *
+ * @param {string} str The string to extract from.
+ * @param {int} from The starting position to extract from.
+ * @param {int} to The ending position to extract to (optional)
+ * @return {string} The extracted substring.
+ */
+varargs string extract(string str, int from, int to) {}
+
+/**
+ * Returns a string with all colour codes removed.
+ *
+ * @param {string} str The string to remove colour from.
+ * @return {string} The string without colour.
+ */
+string no_ansi(string str) {}
+
+/**
+ * Returns a string that is a simple list of the elements of an array,
+ * joined by a conjunction. If no conjunction is provided, "and" will be used.
+ *
+ * @param {string*} arr The array to make a list from.
+ * @param {string} conjunction The word to join the last two elements (optional, default: "and")
+ * @return {string} The simple list string.
+ */
+varargs string simple_list(string *arr, string conjunction) {}
+
+/**
+ * Returns a substring of a string, starting from 0 and ending at the
+ * first occurrence of another string within it. If the reverse flag
+ * is set, the substring will start at the last occurrence of the
+ * substring within the string.
+ *
+ * @param {string} str The string to extract from.
+ * @param {string} sub The substring to extract to.
+ * @param {int} reverse If set, the substring will start at the last occurrence (optional, default: 0)
+ * @return {string} The extracted substring.
+ */
+varargs string substr(string str, string sub, int reverse) {}
+
+/**
+ * Converts a string representation of an LPC value to the
+ * corresponding LPC value. If the flag is set, returns an array with
+ * the value and the remaining string.
+ *
+ * @param {string} str The string to convert.
+ * @param {int} flag If set, returns an array with the value and remaining string (optional, default: 0)
+ * @return {mixed} The LPC value represented by the string.
+ */
+varargs mixed from_string(string str, int flag) {}
+
+/**
+ * Converts an LPC value to its string representation.
+ *
+ * @param {mixed} val The value to convert.
+ * @return {string} The string representation of the value.
+ */
+string stringify(mixed val) {}
+
+/**
+ * Returns a string with commas added to the number. Handles both integer
+ * and floating point numbers, as well as strings that can be converted to numbers.
+ * For negative numbers, the negative sign is preserved at the start.
+ *
+ * @param {mixed} number The number to add commas to.
+ * @return {string} The number with commas added as a string.
+ */
+string add_commas(mixed number) {}
+
+/**
+ * Reverses a string.
+ *
+ * @param {string} str The string to reverse.
+ * @return {string} The reversed string.
+ */
+string reverse_string(string str) {}
+
+/**
+ * Searches for a substring in a string starting from a given position
+ * and moving backwards. If no starting position is provided, starts from
+ * the beginning of the string.
+ *
+ * @param {string} str The string to search in.
+ * @param {string} sub The substring to search for.
+ * @param {int} start The starting position to search from (optional, default: 0)
+ * @return {int} The position of the substring in the string, or -1 if not found.
+ */
+varargs int reverse_strsrch(string str, string sub, int start) {}
+
+/**
+ * Searches for the position of a substring in a string using a
+ * regular expression. If reverse is set, the search will start from
+ * the end of the string.
+ *
+ * @param {string} str The string to search in.
+ * @param {string} substr The regular expression to search for.
+ * @param {int} reverse If set, the search will start from the end (optional, default: 0)
+ * @return {int} The position of the substring in the string, or -1 if not found.
+ */
+varargs int pcre_strsrch(string str, string substr, int reverse) {}
+
+/**
+ * Returns 1 if the string contains colour codes, 0 if not.
+ *
+ * @param {string} str The string to check.
+ * @return {int} 1 if the string contains colour codes, otherwise 0.
+ */
+int colourp(string str) {}
+
+/**
+ * Trims whitespace from both ends of a string.
+ *
+ * @param {string} str The string to trim.
+ * @return {string} The trimmed string.
+ */
+string trim(string str) {}
+
+/**
+ * Trims whitespace from the start of a string.
+ *
+ * @param {string} str The string to trim.
+ * @return {string} The trimmed string.
+ */
+string ltrim(string str) {}
+
+/**
+ * Trims whitespace from the end of a string.
+ *
+ * @param {string} str The string to trim.
+ * @return {string} The trimmed string.
+ */
+string rtrim(string str) {}

--- a/examples/source/lua-library-source/date.lua
+++ b/examples/source/lua-library-source/date.lua
@@ -1,0 +1,32 @@
+---@meta DateClass
+
+------------------------------------------------------------------------------
+-- DateClass
+------------------------------------------------------------------------------
+
+if false then -- ensure that functions do not get defined
+
+  ---@class DateClass
+
+  ---Converts a number of seconds into a human-readable string. By default, the
+  ---result is returned as a table of three strings. However, if the `as_string`
+  ---parameter is provided, the result is returned as a single string.
+  ---
+  ---@example
+  ---```lua
+  ---date.shms(6543)
+  -----"01"
+  -----"49"
+  -----"03"
+  ---
+  ---date.shms(6453, true)
+  ----- "1h 49m 3s"
+  ---```
+  ---
+  ---@name shms
+  ---@param seconds number - The number of seconds to convert.
+  ---@param as_string boolean? - Whether to return the result as a string.
+  ---@return string[]|string # The resulting string or table of strings.
+  function date.shms(seconds, as_string) end
+
+end

--- a/examples/source/lua-library-source/func.lua
+++ b/examples/source/lua-library-source/func.lua
@@ -1,0 +1,50 @@
+---@meta FuncClass
+
+------------------------------------------------------------------------------
+-- FuncClass
+------------------------------------------------------------------------------
+
+if false then -- ensure that functions do not get defined
+
+  ---@class FuncClass
+
+  --- Delays the execution of a function.
+  ---
+  ---@example
+  ---```lua
+  ---func.delay(function() print("Hello, world!") end, 1)
+  ---```
+  ---@name delay
+  ---@param func function - The function to delay.
+  ---@param delay number - The delay in seconds.
+  function func.delay(func, delay, ...) end
+
+  --- Wraps a function in another function.
+  ---
+  ---@example
+  ---```lua
+  ---local becho = func.wrap(cecho, function(func, text)
+  ---  func("<b>{text}</b>")
+  ---end)
+  ---
+  ---becho("Hello, world!")
+  --- -- <b>Hello, world!</b>
+  ---```
+  ---@name wrap
+  ---@param func function - The function to wrap.
+  ---@param wrapper function - The wrapper function.
+  function func.wrap(func, wrapper) end
+
+  --- Repeats a function a given number of times.
+  ---
+  ---@example
+  ---```lua
+  ---func.repeater(function() print("Hello, world!") end, 1, 3)
+  ---```
+  ---@name repeater
+  ---@param func function - The function to repeat.
+  ---@param interval number? - The interval between repetitions (Optional. Default is 1).
+  ---@param times number? - The number of times to repeat the function (Optional. Default is 1).
+  function func.repeater(func, interval, times, ...) end
+
+end

--- a/examples/source/lua-library-source/string.lua
+++ b/examples/source/lua-library-source/string.lua
@@ -1,0 +1,276 @@
+---@meta StringClass
+
+------------------------------------------------------------------------------
+-- StringClass
+------------------------------------------------------------------------------
+
+if false then -- ensure that functions do not get defined
+  ---@class StringClass
+
+  ---Appends a suffix to a string if it does not already end with that suffix. The check
+  ---is done using PCRE regex pattern matching to ensure accurate suffix detection.
+  ---
+  ---@example
+  ---```lua
+  ---string.append("hello", " world")    -- "hello world"
+  ---string.append("hello world", "world") -- "hello world"
+  ---```
+  ---
+  ---@name append
+  ---@param str string - The string to append to.
+  ---@param suffix string - The suffix to append to the string.
+  ---@return string # The resulting string.
+  function string.append(str, suffix) end
+
+  ---Checks if a string contains a given pattern using PCRE regex. This is for finding
+  ---patterns anywhere within the string. The pattern must not start with "^" or end
+  ---with "$" - use starts_with() or ends_with() for those cases instead.
+  ---
+  ---@example
+  ---```lua
+  ---string.contains("hello world", "world")     -- true
+  ---string.contains("hello world", "goodbye")   -- false
+  ---```
+  ---
+  ---@name contains
+  ---@param str string - The string to check.
+  ---@param pattern string - The pattern to check for.
+  ---@return boolean # Whether the string contains the pattern.
+  function string.contains(str, pattern) end
+
+  ---Checks if a string ends with a given pattern using PCRE regex. If the pattern
+  ---doesn't already end with "$", it will be automatically appended to ensure matching
+  ---at the end of the string.
+  ---
+  ---@example
+  ---```lua
+  ---string.ends_with("hello world", "world")     -- true
+  ---string.ends_with("hello world", "hello")     -- false
+  ---string.ends_with("test.lua", "\\.lua$")      -- true
+  ---```
+  ---
+  ---@name ends_with
+  ---@param str string - The string to check.
+  ---@param ending string - The pattern to check for.
+  ---@return boolean # Whether the string ends with the pattern.
+  function string.ends_with(str, ending) end
+
+  ---Formats a number with thousands separators and decimal places. Works with both
+  ---numbers and numeric strings. If not specified, uses "," for thousands and "."
+  ---for decimal separator. Handles negative numbers and maintains decimal precision.
+  ---
+  ---@example
+  ---```lua
+  ---string.format_number(1234567.89)           -- "1,234,567.89"
+  ---string.format_number(-1234.56)             -- "-1,234.56"
+  ---string.format_number(1234567, ".", ",")    -- "1.234.567"
+  ---```
+  ---
+  ---@name format_number
+  ---@param number number|string - The number to format.
+  ---@param thousands string? - The thousands separator.
+  ---@param decimal string? - The decimal separator.
+  ---@return string # The formatted number.
+  function string.format_number(number, thousands, decimal) end
+
+  ---Removes whitespace characters from the beginning (left side) of a string.
+  ---Whitespace includes spaces, tabs, and newlines.
+  ---
+  ---@example
+  ---```lua
+  ---string.ltrim("  hello world  ")    -- "hello world  "
+  ---string.ltrim("\t\nhello")          -- "hello"
+  ---```
+  ---
+  ---@name ltrim
+  ---@param str string - The string to remove whitespace from.
+  ---@return string # The resulting string without whitespace on the left.
+  function string.ltrim(str) end
+
+  ---Converts a formatted number string back into a number. Handles thousands and
+  ---decimal separators, removing the thousands separators and converting the decimal
+  ---separator to a period if necessary.
+  ---
+  ---@example
+  ---```lua
+  ---string.parse_formatted_number("1,234,567.89")       -- 1234567.89
+  ---string.parse_formatted_number("1.234.567,89", ".", ",")  -- 1234567.89
+  ---```
+  ---
+  ---@name parse_formatted_number
+  ---@param str string - The string to parse.
+  ---@param thousands string? - The thousands separator.
+  ---@param decimal string? - The decimal separator.
+  ---@return number # The parsed number.
+  function string.parse_formatted_number(str, thousands, decimal) end
+
+  ---Prepends a prefix to a string if it does not already start with that prefix.
+  ---Uses PCRE regex pattern matching to ensure accurate prefix detection.
+  ---
+  ---@example
+  ---```lua
+  ---string.prepend("world", "hello ")          -- "hello world"
+  ---string.prepend("hello world", "hello")     -- "hello world"
+  ---```
+  ---
+  ---@name prepend
+  ---@param str string - The string to prepend to.
+  ---@param prefix string - The prefix to prepend to the string.
+  ---@return string # The resulting string.
+  function string.prepend(str, prefix) end
+
+  ---Performs pattern matching using reg_assoc with PCRE regex support. Associates
+  ---patterns with tokens and returns both the matched segments and their corresponding
+  ---token assignments.
+  ---
+  ---@example
+  ---```lua
+  ---local results, tokens = string.reg_assoc(
+  ---    "hello world",
+  ---    {"hello", "world"},
+  ---    {"greeting", "place"}
+  ---)
+  ---- results: {"hello", " ", "world"}
+  ---- tokens: {"greeting", -1, "place"}
+  ---```
+  ---
+  ---@name reg_assoc
+  ---@param text string - The text to search through
+  ---@param patterns table - The patterns to search for
+  ---@param tokens table - The tokens to replace the patterns with
+  ---@param default_token string? - The default token for unmatched text
+  ---@return table,table # The results table and token list
+  function string.reg_assoc(text, patterns, tokens, default_token) end
+
+  ---Replaces all occurrences of a pattern in a string with a replacement string.
+  ---Continues replacing until no more matches are found to handle overlapping or
+  ---repeated patterns.
+  ---
+  ---@example
+  ---```lua
+  ---string.replace("hello world", "o", "a")     -- "hella warld"
+  ---string.replace("test", "t", "p")            -- "pesp"
+  ---```
+  ---
+  ---@name replace
+  ---@param str string - The string to replace the pattern in.
+  ---@param pattern string - The pattern to replace.
+  ---@param replacement string - The replacement string.
+  ---@return string # The resulting string.
+  function string.replace(str, pattern, replacement) end
+
+  ---Removes whitespace characters from the end (right side) of a string.
+  ---Whitespace includes spaces, tabs, and newlines.
+  ---
+  ---@example
+  ---```lua
+  ---string.rtrim("  hello world  ")    -- "  hello world"
+  ---string.rtrim("hello\t\n")          -- "hello"
+  ---```
+  ---
+  ---@name rtrim
+  ---@param str string - The string to remove whitespace from.
+  ---@return string # The resulting string without whitespace on the right.
+  function string.rtrim(str) end
+
+  ---Splits a string into a table of strings using PCRE regex. If no delimiter
+  ---is provided, it defaults to ".", which will split the string into individual
+  ---characters. The delimiter is treated as a regex pattern.
+  ---
+  ---@example
+  ---```lua
+  ---string.split("hello world")           -- {"h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"}
+  ---string.split("hello world", " ")      -- {"hello", "world"}
+  ---string.split("hello.world", "\\.")    -- {"hello", "world"}
+  ---string.split("hello world", "o")      -- {"hell", " w", "rld"}
+  ---```
+  ---
+  ---@name split
+  ---@param str string - The string to split.
+  ---@param delimiter string? - The regex delimiter to split the string by.
+  ---@return string[] # The resulting array of strings.
+  function string.split(str, delimiter) end
+
+  ---Checks if a string starts with a given pattern using PCRE regex. If the pattern
+  ---doesn't already start with "^", it will be automatically prepended to ensure
+  ---matching at the start of the string.
+  ---
+  ---@example
+  ---```lua
+  ---string.starts_with("hello world", "hello")     -- true
+  ---string.starts_with("hello world", "world")     -- false
+  ---string.starts_with("test.lua", "^test")        -- true
+  ---```
+  ---
+  ---@name starts_with
+  ---@param str string - The string to check.
+  ---@param start string - The pattern to check for.
+  ---@return boolean # Whether the string starts with the pattern.
+  function string.starts_with(str, start) end
+
+  ---Removes all line breaks from a string, including both \r and \n characters.
+  ---Useful for converting multi-line text into a single line.
+  ---
+  ---@example
+  ---```lua
+  ---string.strip_linebreaks("hello\nworld")     -- "helloworld"
+  ---string.strip_linebreaks("hello\r\nworld")   -- "helloworld"
+  ---```
+  ---
+  ---@name strip_linebreaks
+  ---@param str string - The string to strip line breaks from.
+  ---@return string # The resulting string without line breaks.
+  function string.strip_linebreaks(str) end
+
+  ---Removes whitespace from both the beginning and end of a string.
+  ---Whitespace includes spaces, tabs, and newlines.
+  ---
+  ---@example
+  ---```lua
+  ---string.trim("  hello world  ")    -- "hello world"
+  ---string.trim("\t\nhello\n\t")      -- "hello"
+  ---```
+  ---
+  ---@name trim
+  ---@param str string - The string to trim.
+  ---@return string # The trimmed string.
+  function string.trim(str) end
+
+  ---Creates an iterator that walks through a string character by character or by
+  ---split segments if a delimiter is provided. Returns index and value pairs.
+  ---
+  ---@example
+  ---```lua
+  ---for i, part in string.walk("hello world") do
+  ---  print(i, part)  -- prints: 1,"h" 2,"e" 3,"l" 4,"l" 5,"o" 6," " 7,"w" 8,"o" 9,"r" 10,"l" 11,"d"
+  ---end
+  ---
+  ---for i, part in string.walk("a,b,c", ",") do
+  ---  print(i, part)  -- prints: 1,"a" 2,"b" 3,"c"
+  ---end
+  ---```
+  ---
+  ---@name walk
+  ---@param input string - The string to walk through.
+  ---@param delimiter string? - The delimiter to split the string by.
+  ---@return function # The iterator function.
+  function string.walk(input, delimiter) end
+
+  ---Returns the index of the first occurrence of a pattern in a string.
+  ---This function uses PCRE regex to find the pattern.
+  ---
+  ---@example
+  ---```lua
+  ---string.index_of("hello world", "world")   -- 7
+  ---string.index_of("hello world", "o")       -- 4
+  ---string.index_of("hello world", "x")       -- nil
+  ---string.index_of("hello world", "[aeiou]") -- 2
+  ---string.index_of("hello world", "\\s")     -- 5
+  ---```
+  ---
+  ---@name index_of
+  ---@param str string - The string to search through.
+  ---@param pattern string - The pattern to search for.
+  ---@return number # The index of the pattern.
+  function string.index_of(str, pattern) end
+end

--- a/examples/source/lua-library-source/table.lua
+++ b/examples/source/lua-library-source/table.lua
@@ -1,0 +1,643 @@
+---@meta TableClass
+
+------------------------------------------------------------------------------
+-- TableClass
+------------------------------------------------------------------------------
+
+if false then -- ensure that functions do not get defined
+
+  ---@class TableClass
+
+  ---Adds a second associative table to a first associative table, merging the
+  ---second table into the first.
+  ---
+  ---@example
+  ---```lua
+  ---table.add({ a = 1 }, { b = 2 })
+  ----- { a = 1, b = 2 }
+  ---
+  ---table.add({ a = 1, b = 2 }, { b = 3, c = 4 })
+  ----- { a = 1, b = 3, c = 4 }
+  ---```
+  ---
+  ---@name add
+  ---@param table1 table - The table to add the value to.
+  ---@param table2 table - The table to add to the first table.
+  ---@return table # The first table with the second table added.
+  function table.add(table1, table2) end
+
+  ---Allocates a new table with given an initial indexed table and a
+  ---specification for the new table.
+  ---
+  ---The specification can be:
+  ---* another indexed table, in which case the new table will be created with
+  ---  the same values as the source table, but with the values in the spec table
+  ---  applied to each corresponding value in the source table. The second table
+  ---  must have the same number of elements as the source table.
+  ---* a function, in which case the function will be applied to each value in
+  ---  the source table to produce the values in the new table.
+  ---* a single type, in which case all values in the new table will be of
+  ---  that type
+  ---
+  ---@example
+  ---```lua
+  ---table.allocate({"a", "b", "c"}, "x")
+  ----- {a = "x", b = "x", c = "x"}
+  ---
+  ---table.allocate({"a","b","c"}, {1, 2, 3})
+  ----- {a = 1, b = 2, c = 3}
+  ---
+  ---table.allocate({ "a", "b", "c" }, function(k, v)
+  ---  return string.byte(v)
+  ---end)
+  ----- {a = 97, b = 98, c = 99}
+  ---```
+  ---@name allocate
+  ---@param source table - The table to copy.
+  ---@param spec table - The specification for the new table.
+  ---@return table # The new table.
+  function table.allocate(source, spec) end
+
+  ---Returns true if the table is associative, false otherwise.
+  ---
+  ---@example
+  ---```lua
+  ---table.associative({ a = 1, b = 2 })
+  ----- true
+  ---
+  ---table.associative({ 1, 2, 3 })
+  ----- false
+  ---```
+  ---
+  ---@name associative
+  ---@param t table - The table to check.
+  ---@return boolean # True if the table is associative, false otherwise.
+  function table.associative(t) end
+
+  ---Returns a table of tables, each containing a slice of the original table
+  ---of specified size. If there are not enough elements to fill the last
+  ---chunk, the last chunk will contain the remaining elements.
+  ---
+  ---@example
+  ---```lua
+  ---table.chunk({1, 2, 3, 4, 5}, 2)
+  ----- {{1, 2}, {3, 4}, {5}}
+  ---```
+  ---
+  ---@name chunk
+  ---@param t table - The table to chunk.
+  ---@param size number - The size of each chunk.
+  ---@return table # A table of tables, each containing a slice of the original table.
+  function table.chunk(t, size) end
+
+  ---Creates a new table by concatenating the original table with any
+  ---additional arrays and/or values. If the arguments contains tables, they
+  ---will be concatenated with the original table. Otherwise, the values will
+  ---be added to the end of the original table.
+  ---@example
+  ---```lua
+  ---table.concat({1}, 2, {3}, {{4}})
+  ----- {1, 2, 3, {4}}
+  ---```
+  ---
+  ---@name concat
+  ---@param tbl table - The first table to concatenate.
+  ---@param ... any - Additional tables and/or values to concatenate.
+  ---@return table # A new table containing the concatenated tables.
+  function table.concat(tbl, ...) end
+
+  ---Drops the first n elements from an indexed table.
+  ---
+  ---@name drop
+  ---@param tbl table - The table to drop elements from.
+  ---@param n number - The number of elements to drop.
+  ---@return table # A new table with the first n elements removed.
+  function table.drop(tbl, n) end
+
+  ---Drops the last n elements from an indexed table.
+  ---
+  ---@name drop_right
+  ---@param tbl table - The table to drop elements from.
+  ---@param n number - The number of elements to drop.
+  ---@return table # A new table with the last n elements removed.
+  function table.drop_right(tbl, n) end
+
+  ---Returns a random element from the keys of a table, with each value
+  ---representing a weight.
+  ---
+  ---@example
+  ---```lua
+  ---table.element_of_weighted({ [1] = 10, [2] = 20, [3] = 70 })
+  ----- 3
+  ---```
+  ---
+  ---@name element_of_weighted
+  ---@param list table - The table to choose an element from.
+  ---@return any # A random element from the table.
+  function table.element_of_weighted(list) end
+
+  ---Returns a random element from an indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---table.element_of({1, 2, 3})
+  ----- 2
+  ---```
+  ---
+  ---@name element_of
+  ---@param list table - The table to choose an element from.
+  ---@return any # A random element from the table.
+  function table.element_of(list) end
+
+  ---Fills an indexed table with a value.
+  ---
+  ---If the start index is not provided, it will fill from the beginning of the
+  ---table. If the stop index is not provided, it will fill to the end of the
+  ---table.
+  ---
+  ---@example
+  ---```lua
+  ---table.fill({1, 2, 3, 4, 5}, "x")
+  ----- {"x", "x", "x", "x", "x"}
+  ---
+  ---table.fill({1, 2, 3, 4, 5}, "x", 2)
+  ----- {1, "x", "x", 4, 5}
+  ---
+  ---table.fill({1, 2, 3, 4, 5}, "x", 2, 4)
+  ----- {1, "x", "x", "x", 5}
+  ---```
+  ---
+  ---@name fill
+  ---@param tbl table - The table to fill.
+  ---@param value any - The value to fill the table with.
+  ---@param start number? - The start index to fill.
+  ---@param stop number? - The stop index to fill.
+  ---@return table # The filled table.
+  function table.fill(tbl, value, start, stop) end
+
+  ---Returns the index of the first element in a table that satisfies a
+  ---predicate function.
+  ---
+  ---@example
+  ---```lua
+  ---table.find({1, 2, 3, 4, 5}, function(v) return v > 3 end)
+  ----- 4
+  ---```
+  ---
+  ---@name find
+  ---@param tbl table - The table to find the index of the first element in.
+  ---@param fn function - The predicate function to satisfy.
+  ---@return number|nil # The index of the first element that satisfies the predicate function, or nil if no element satisfies the predicate.
+  function table.find(tbl, fn) end
+
+
+  ---Returns the index of the last element in a table that satisfies a
+  ---predicate function.
+  ---
+  ---@example
+  ---```lua
+  ---table.find_last({1, 2, 3, 4, 5}, function(v) return v > 3 end)
+  ----- 4
+  ---```
+  ---
+  ---@name find_last
+  ---@param tbl table - The table to find the index of the last element in.
+  ---@param fn function - The predicate function to satisfy.
+  ---@return number? # The index of the last element that satisfies the predicate function, or nil if no element satisfies the predicate.
+  function table.find_last(tbl, fn) end
+
+  ---Flattens a table of tables into a single table recursively.
+  ---
+  ---@example
+  ---```lua
+  ---table.flatten_deeply({1, {2, {3, {4}}, 5}})
+  ----- {1, 2, 3, 4, 5}
+  ---```
+  ---
+  ---@name flatten_deeply
+  ---@param tbl table - The table to flatten recursively.
+  ---@return table # A new table containing the flattened table.
+  function table.flatten_deeply(tbl) end
+
+  ---Flattens a table of tables into a single table.
+  ---
+  ---@example
+  ---```lua
+  ---table.flatten({1, {2, {3, {4}}, 5}})
+  ----- {1, 2, 3, 4, 5}
+  ---```
+  ---
+  ---@name flatten
+  ---@param tbl table - The table to flatten.
+  ---@return table # A new table containing the flattened table.
+  function table.flatten(tbl) end
+
+  ---Returns a table of the functions in a table.
+  ---
+  ---@example
+  ---```lua
+  ---table.functions({a = 1, b = 2, c = end})
+  ----- {c = function()}
+  ---```
+  ---
+  ---@name functions
+  ---@param tbl table - The table to get the functions from.
+  ---@param inherited boolean? - Whether to include inherited functions.
+  ---@return table # A table of the functions in the table.
+  function table.functions(tbl, inherited) end
+
+  ---Returns true if an indexed table includes a value, false otherwise.
+  ---
+  ---@example
+  ---```lua
+  ---table.includes({1, 2, 3}, 2)
+  ----- true
+  ---```
+  ---
+  ---@name includes
+  ---@param tbl table - The table to check.
+  ---@param value any - The value to check for.
+  ---@return boolean # True if the table includes the value, false otherwise.
+  function table.includes(tbl, value) end
+
+  ---Returns true if a table is indexed, false otherwise.
+  ---
+  ---@example
+  ---```lua
+  ---table.indexed({1, 2, 3})
+  ----- true
+  ---
+  ---table.indexed({ a = 1, b = 2 })
+  ----- false
+  ---```
+  ---
+  ---@name indexed
+  ---@param t table - The table to check.
+  ---@return boolean # True if the table is indexed, false otherwise.
+  function table.indexed(t) end
+
+  ---Returns an indexed table with the last element removed from the original
+  ---indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---table.initial({1, 2, 3, 4, 5})
+  ----- {1, 2, 3, 4}
+  ---```
+  ---
+  ---@name initial
+  ---@param tbl table - The table to remove the last element from.
+  ---@return table # A new table with the last element removed.
+  function table.initial(tbl) end
+
+  ---Returns true if a table is an object, false otherwise.
+  ---
+  ---@example
+  ---```lua
+  ---local object1 = {1,2,3}
+  ---local object2 = {}
+  ---setmetatable(object2, { __index = object1 })
+  ---
+  ---table.object(object1)
+  ----- false
+  ---table.object(object2)
+  ----- true
+  ---```
+  ---
+  ---@name object
+  ---@param tbl table - The table to check.
+  ---@return boolean # True if the table is an object, false otherwise.
+  function table.object(tbl) end
+
+  ---Returns a new table with a function applied to each element of the original
+  ---table, transforming each element into a new value.
+  ---
+  ---@example
+  ---```lua
+  ---table.map({1, 2, 3}, function(v) return v * 2 end)
+  ----- {2, 4, 6}
+  ---```
+  ---
+  ---@name map
+  ---@param t table - The table to map over.
+  ---@param fn function - The function to map over the table.
+  ---@param ... any - Additional arguments to pass to the function.
+  ---@return table # A new table with the function applied to each element.
+  function table.map(t, fn, ...) end
+
+  ---Appends or inserts a second indexed table into a first indexed table at
+  ---a specified index.
+  ---
+  ---If the index is not provided, the second table is appended to the end of
+  ---the first table. If the index is provided, the second table is inserted into
+  ---the first table at the specified index.
+  ---
+  ---@example
+  ---```lua
+  ---table.n_add({1, 2, 3}, {4, 5, 6})
+  ----- {1, 2, 3, 4, 5, 6}
+  ---
+  ---table.n_add({1, 2, 3}, {4, 5, 6}, 2)
+  ----- { 1, 4, 5, 6, 2, 3 }
+  ---```
+  ---
+  ---@name n_add
+  ---@param tbl1 table - The first table to add the value to.
+  ---@param tbl2 table - The second table to add to the first table.
+  ---@param index number? - The index to add the second table to.
+  ---@return table # The first table with the second table added.
+  function table.n_add(tbl1, tbl2, index) end
+
+  ---Casts a value to an indexed table if it is not already one.
+  ---
+  ---@example
+  ---```lua
+  ---table.n_cast(1)
+  ----- {1}
+  ---
+  ---table.n_cast({1, 2, 3})
+  ----- {1, 2, 3}
+  ---```
+  ---
+  ---@name n_cast
+  ---@param ... any - The value to cast.
+  ---@return table # A new indexed table with the value or the value itself if it is already indexed.
+  function table.n_cast(...) end
+
+  ---Returns a new table with the distinct elements of an indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---table.n_distinct({1, 2, 3, 2, 1})
+  ----- {1, 2, 3}
+  ---```
+  ---
+  ---@name n_distinct
+  ---@param t table - The table to get the distinct elements from.
+  ---@return table # A new table with the distinct elements.
+  function table.n_distinct(t) end
+
+  ---Returns true or false if all elements in an indexed table are of the same
+  ---type. If a type is not provided, it will check if all elements are of the
+  ---same type as the first element in the table.
+  ---
+  ---@example
+  ---```lua
+  ---table.n_uniform({1, 2, 3}, "number")
+  ----- true
+  ---```
+  ---
+  ---@name n_uniform
+  ---@param t table - The table to check.
+  ---@param typ string? - The type to check for.
+  ---@return boolean # True if all elements are of the same type, false otherwise.
+  function table.n_uniform(t, typ) end
+
+  ---Creates a new table with weak references. Valid options are "v" for
+  ---weak values, "k" for weak keys, and "kv" or "vk" for weak keys and
+  ---values.
+  ---
+  ---@example
+  ---```lua
+  ---table.new_weak("v")
+  ----- A table with weak value references
+  ---```
+  ---
+  ---@name new_weak
+  ---@param opt string? - The reference type.
+  ---@return table # A new table with weak references.
+  function table.new_weak(opt) end
+
+  ---Removes and returns the last element of an indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---local sample = {1, 2, 3}
+  ---table.pop(sample)
+  ----- 3
+  ----- sample = {1, 2}
+  ---```
+  ---
+  ---@name pop
+  ---@param t table - The table to remove the last element from.
+  ---@return any # The last element of the table.
+  function table.pop(t) end
+
+  ---Returns a table of the properties of a table. This function only returns
+  ---the properties of the table itself, not the properties of any metatables,
+  ---and no functions.
+  ---
+  ---If the inherited parameter is true, it will include the properties of any
+  ---metatables.
+  ---
+  ---@example
+  ---```lua
+  ---table.properties({a = 1, b = 2})
+  ----- {a = 1, b = 2}
+  ---```
+  ---
+  ---@name properties
+  ---@param tbl table - The table to get the properties from.
+  ---@param inherited boolean? - Whether to include inherited properties.
+  ---@return table # A table of the properties of the table.
+  function table.properties(tbl, inherited) end
+
+  ---Adds a value to the end of an indexed table, returning the new length of
+  ---the table.
+  ---
+  ---@example
+  ---```lua
+  ---table.push({1, 2, 3}, 4)
+  ----- 4
+  ---```
+  ---
+  ---@name push
+  ---@param t table - The table to append the value to.
+  ---@param v any - The value to append to the table.
+  ---@return number # The new length of the table.
+  function table.push(t, v) end
+
+  ---Reduces an indexed table to a single value using a reducer function.
+  ---
+  ---@example
+  ---```lua
+  ---table.reduce({1, 2, 3}, function(acc, v) return acc + v end, 0)
+  ----- 6
+  ---```
+  ---
+  ---@name reduce
+  ---@param t table - The table to reduce.
+  ---@param fn function - The reducer function.
+  ---@param initial any? - The initial value.
+  ---@return any # The reduced value.
+  function table.reduce(t, fn, initial) end
+
+  ---Removes and returns a slice of a table from the start index to the stop
+  ---index. If the stop index is not provided, it will only remove the element
+  ---at the start index. A second return value is also provided containing the
+  ---removed slice.
+  ---
+  ---@example
+  ---```lua
+  ---table.remove({1, 2, 3, 4, 5}, 2, 4)
+  ----- {1, 5}
+  ----- {2, 3, 4}
+  ---
+  ---table.remove({1, 2, 3, 4, 5}, 2)
+  ----- {1, 3, 4, 5}
+  ----- {2}
+  ---```
+  ---
+  ---@name remove
+  ---@param t table - The table to remove the slice from.
+  ---@param start number - The start index of the slice.
+  ---@param stop number? - The stop index of the slice.
+  ---@return table # A new table containing the removed slice.
+  function table.remove(t, start, stop) end
+
+  ---Reverses an indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---table.reverse({1, 2, 3})
+  ----- {3, 2, 1}
+  ---```
+  ---
+  ---@name reverse
+  ---@param tbl table - The table to reverse.
+  ---@return table # A new reversed table.
+  function table.reverse(tbl) end
+
+  ---Removes and returns the first element of an indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---table.shift({1, 2, 3})
+  ----- 1
+  ---```
+  ---
+  ---@name shift
+  ---@param t table - The table to remove the first element from.
+  ---@return any # The first element of the table.
+  function table.shift(t) end
+
+  ---Returns a slice of an indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---table.slice({1, 2, 3, 4, 5}, 2, 4)
+  ----- {2, 3, 4}
+  ---```
+  ---
+  ---@name slice
+  ---@param t table - The table to slice.
+  ---@param start number? - The start index.
+  ---@param stop number? - The stop index.
+  ---@return table # A new table with the slice.
+  function table.slice(t, start, stop) end
+
+  ---Returns a new table with the unique elements of an indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---table.uniq({1, 2, 3, 2, 1})
+  ----- {1, 2, 3}
+  ---```
+  ---
+  ---@name uniq
+  ---@param tbl table - The table to get the unique elements from.
+  ---@return table # A new table with the unique elements.
+  function table.uniq(tbl) end
+
+  ---Adds a value to the beginning of an indexed table.
+  ---
+  ---@example
+  ---```lua
+  ---table.unshift({1, 2, 3}, 4)
+  ----- 4
+  ---```
+  ---
+  ---@name unshift
+  ---@param t table - The table to add the value to.
+  ---@param v any - The value to add to the table.
+  ---@return number # The new length of the table.
+  function table.unshift(t, v) end
+
+  ---Unzips a table of tables into a table of tables. The index of the new
+  ---sub-tables will be the same as the index of the sub-tables in the original
+  ---table.
+  ---
+  ---@example
+  ---```lua
+  ---local combined = {{"John", 25}, {"Jane", 30}, {"Jim", 35}}
+  ---local names, ages = unpack(table.unzip(combined))
+  ----- names = {"John", "Jane", "Jim"}
+  ----- ages = {25, 30, 35}
+  ---```
+  ---
+  ---@name unzip
+  ---@param tbl table - The table to unzip.
+  ---@return table # A table of tables.
+  function table.unzip(tbl) end
+
+  ---Returns an indexed table with the values of an associative table.
+  ---
+  ---@example
+  ---```lua
+  ---table.values({a = 1, b = 2})
+  ----- {1, 2}
+  ---```
+  ---
+  ---@name values
+  ---@param t table - The table to get the values from.
+  ---@return table # An indexed table with the values.
+  function table.values(t) end
+
+  ---Returns an iterator function that can be used to walk over an indexed
+  ---table.
+  ---
+  ---@example
+  ---```lua
+  ---table.walk({1, 2, 3}, function(v) print(v) end)
+  ----- 1
+  ----- 2
+  ----- 3
+  ---```
+  ---
+  ---@name walk
+  ---@param tbl table - The table to walk over.
+  ---@return function # An iterator function.
+  function table.walk(tbl) end
+
+  ---Returns a new table with weak references. Valid options are "v" for
+  ---weak values, "k" for weak keys, and "kv" or "vk" for weak keys and
+  ---values.
+  ---
+  ---@example
+  ---```lua
+  ---table.weak("v")
+  ----- A table with weak value references
+  ---```
+  ---
+  ---@name weak
+  ---@param opt string? - The reference type.
+  ---@return table # A new table with weak references.
+  function table.weak(opt) end
+
+  ---Zips multiple tables together. The tables must all be of the same length.
+  ---
+  ------ @example
+  ---```lua
+  ---local names = {"John", "Jane", "Jim"}
+  ---local ages = {25, 30, 35}
+  ---
+  ---table.zip(names, ages)
+  ----- {{"John", 25}, {"Jane", 30}, {"Jim", 35}}
+  ---```
+  ---
+  ---@name zip
+  ---@param ... table - The tables to zip together.
+  ---@return table # A new table containing the zipped tables.
+  function table.zip(...) end
+
+end

--- a/examples/source/lua/date.lua
+++ b/examples/source/lua/date.lua
@@ -1,32 +1,61 @@
----@meta DateClass
+local DateClass = Glu.glass.register({
+  class_name = "DateClass",
+  name = "date",
+  dependencies = {},
+  setup = function(___, self, opts)
+    local v = ___.v
 
-------------------------------------------------------------------------------
--- DateClass
-------------------------------------------------------------------------------
+    function self.shms(seconds, as_string)
+      v.type(seconds, "number", 1, false)
+      v.type(as_string, "boolean", 2, true)
 
-if false then -- ensure that functions do not get defined
+      local s = seconds or 0
 
-  ---@class DateClass
+      -- Handle negative seconds
+      local is_negative = s < 0
+      s = math.abs(s)
 
-  ---Converts a number of seconds into a human-readable string. By default, the
-  ---result is returned as a table of three strings. However, if the `as_string`
-  ---parameter is provided, the result is returned as a single string.
-  ---
-  ---@example
-  ---```lua
-  ---date.shms(6543)
-  -----"01"
-  -----"49"
-  -----"03"
-  ---
-  ---date.shms(6453, true)
-  ----- "1h 49m 3s"
-  ---```
-  ---
-  ---@name shms
-  ---@param seconds number - The number of seconds to convert.
-  ---@param as_string boolean? - Whether to return the result as a string.
-  ---@return string[]|string # The resulting string or table of strings.
-  function date.shms(seconds, as_string) end
+      -- Hours
+      local hh = math.floor(s / (60 * 60))
+      -- Minutes
+      local mm = math.floor((s % (60 * 60)) / 60)
+      -- Seconds
+      local ss = s % 60
 
-end
+      if is_negative then
+        -- Adjust for negative seconds
+        if ss > 0 then
+          ss = 60 - ss
+          mm = mm + 1
+        end
+
+        if mm > 0 then
+          mm = 60 - mm
+          hh = (hh == 0) and 23 or (hh - 1)
+        else
+          hh = (hh == 0) and 23 or (hh - 1)
+        end
+      end
+
+      if as_string then
+        local r = {}
+        if hh ~= 0 then
+          r[#r + 1] = hh .. "h"
+        end
+        if mm ~= 0 then
+          r[#r + 1] = mm .. "m"
+        end
+        if ss ~= 0 then
+          r[#r + 1] = ss .. "s"
+        end
+
+        return table.concat(r, " ") or "0s"
+      else
+        local result_hours = string.format("%02d", hh)
+        local result_minutes = string.format("%02d", mm)
+        local result_seconds = string.format("%02d", ss)
+        return result_hours, result_minutes, result_seconds
+      end
+    end
+  end
+})

--- a/examples/source/lua/func.lua
+++ b/examples/source/lua/func.lua
@@ -1,50 +1,52 @@
----@meta FuncClass
+local FuncClass = Glu.glass.register({
+  name = "func",
+  class_name = "FuncClass",
+  dependencies = {},
+  setup = function(___, self)
+    function self.delay(func, delay, ...)
+      ___.v.type(func, "function", 1, false)
+      ___.v.type(delay, "number", 2, false)
 
-------------------------------------------------------------------------------
--- FuncClass
-------------------------------------------------------------------------------
+      ---@diagnostic disable-next-line: return-type-mismatch
+      return tempTimer(delay, function(...)
+        func(...)
+      end)
+    end
 
-if false then -- ensure that functions do not get defined
+    function self.wrap(func, wrapper)
+      --- ```lua
+      --- local becho = function.wrap(cecho, function(func, text)
+      ---   func("<b>{text}</b>")
+      --- end)
+      ---
+      --- becho("Hello, world!")
+      --- -- <b>Hello, world!</b>
+      --- ```
+      ___.v.type(func, "function", 1, false)
+      ___.v.type(wrapper, "function", 2, false)
 
-  ---@class FuncClass
+      return function(...)
+        return wrapper(func, ...)
+      end
+    end
 
-  --- Delays the execution of a function.
-  ---
-  ---@example
-  ---```lua
-  ---func.delay(function() print("Hello, world!") end, 1)
-  ---```
-  ---@name delay
-  ---@param func function - The function to delay.
-  ---@param delay number - The delay in seconds.
-  function func.delay(func, delay, ...) end
+    function self.repeater(func, interval, times, ...)
+      ___.v.type(func, "function", 1, false)
+      ___.v.type(interval, "number", 2, true)
+      ___.v.type(times, "number", 3, true)
 
-  --- Wraps a function in another function.
-  ---
-  ---@example
-  ---```lua
-  ---local becho = func.wrap(cecho, function(func, text)
-  ---  func("<b>{text}</b>")
-  ---end)
-  ---
-  ---becho("Hello, world!")
-  --- -- <b>Hello, world!</b>
-  ---```
-  ---@name wrap
-  ---@param func function - The function to wrap.
-  ---@param wrapper function - The wrapper function.
-  function func.wrap(func, wrapper) end
+      interval = interval or 1
+      times = times or 1
 
-  --- Repeats a function a given number of times.
-  ---
-  ---@example
-  ---```lua
-  ---func.repeater(function() print("Hello, world!") end, 1, 3)
-  ---```
-  ---@name repeater
-  ---@param func function - The function to repeat.
-  ---@param interval number? - The interval between repetitions (Optional. Default is 1).
-  ---@param times number? - The number of times to repeat the function (Optional. Default is 1).
-  function func.repeater(func, interval, times, ...) end
-
-end
+      local count = 0
+      local function _repeat(...)
+        if count < times then
+          func(...)
+          count = count + 1
+          tempTimer(interval, _repeat, ...)
+        end
+      end
+      _repeat(...)
+    end
+  end
+})

--- a/examples/source/lua/string.lua
+++ b/examples/source/lua/string.lua
@@ -1,276 +1,535 @@
----@meta StringClass
+local StringClass = Glu.glass.register({
+  name = "string",
+  class_name = "StringClass",
+  dependencies = { "table" },
+  setup = function(___, self)
+    --- Capitalizes the first character of a string.
+    ---
+    --- @param str string - The string to capitalize.
+    --- @return string - The capitalized string.
+    --- @example
+    --- ```lua
+    --- string.capitalize("hello")
+    --- -- "Hello"
+    --- ```
+    function self.capitalize(str)
+      ___.v.type(str, "string", 1, false)
+      assert(str ~= "", "Expected a non-empty string")
 
-------------------------------------------------------------------------------
--- StringClass
-------------------------------------------------------------------------------
+      local result = str:gsub("^%l", string.upper)
+      return result or str
+    end
 
-if false then -- ensure that functions do not get defined
-  ---@class StringClass
+    --- Trims whitespace from the beginning and end of a string.
+    ---
+    --- @param str string - The string to trim.
+    --- @return string - The trimmed string.
+    --- @example
+    --- ```lua
+    --- string.trim("  hello  ")
+    --- -- "hello"
+    --- ```
+    function self.trim(str)
+      ___.v.type(str, "string", 1, false)
+      return str:match("^%s*(.-)%s*$")
+    end
 
-  ---Appends a suffix to a string if it does not already end with that suffix. The check
-  ---is done using PCRE regex pattern matching to ensure accurate suffix detection.
-  ---
-  ---@example
-  ---```lua
-  ---string.append("hello", " world")    -- "hello world"
-  ---string.append("hello world", "world") -- "hello world"
-  ---```
-  ---
-  ---@name append
-  ---@param str string - The string to append to.
-  ---@param suffix string - The suffix to append to the string.
-  ---@return string # The resulting string.
-  function string.append(str, suffix) end
+    --- Trims whitespace from the left side of a string.
+    ---
+    --- @param str string - The string to trim.
+    --- @return string - The trimmed string.
+    --- @example
+    --- ```lua
+    --- string.ltrim("  hello  ")
+    --- -- "hello  "
+    --- ```
+    function self.ltrim(str)
+      ___.v.type(str, "string", 1, false)
+      return str:match("^%s*(.-)$")
+    end
 
-  ---Checks if a string contains a given pattern using PCRE regex. This is for finding
-  ---patterns anywhere within the string. The pattern must not start with "^" or end
-  ---with "$" - use starts_with() or ends_with() for those cases instead.
-  ---
-  ---@example
-  ---```lua
-  ---string.contains("hello world", "world")     -- true
-  ---string.contains("hello world", "goodbye")   -- false
-  ---```
-  ---
-  ---@name contains
-  ---@param str string - The string to check.
-  ---@param pattern string - The pattern to check for.
-  ---@return boolean # Whether the string contains the pattern.
-  function string.contains(str, pattern) end
+    --- Trims whitespace from the right side of a string.
+    ---
+    --- @param str string - The string to trim.
+    --- @return string - The trimmed string.
+    --- @example
+    --- ```lua
+    --- string.rtrim("  hello  ")
+    --- -- "  hello"
+    --- ```
+    function self.rtrim(str)
+      ___.v.type(str, "string", 1, false)
+      return str:match("^.-%s*$")
+    end
 
-  ---Checks if a string ends with a given pattern using PCRE regex. If the pattern
-  ---doesn't already end with "$", it will be automatically appended to ensure matching
-  ---at the end of the string.
-  ---
-  ---@example
-  ---```lua
-  ---string.ends_with("hello world", "world")     -- true
-  ---string.ends_with("hello world", "hello")     -- false
-  ---string.ends_with("test.lua", "\\.lua$")      -- true
-  ---```
-  ---
-  ---@name ends_with
-  ---@param str string - The string to check.
-  ---@param ending string - The pattern to check for.
-  ---@return boolean # Whether the string ends with the pattern.
-  function string.ends_with(str, ending) end
+    --- Strips line breaks from a string.
+    ---
+    --- @param str string - The string to strip line breaks from.
+    --- @return string - The string with line breaks removed.
+    --- @example
+    --- ```lua
+    --- string.strip_linebreaks("hello\nworld")
+    --- -- "helloworld"
+    --- ```
+    function self.strip_linebreaks(str)
+      ___.v.type(str, "string", 1, false)
+      local result = str:gsub("[\r\n]", "")
+      return result or str
+    end
 
-  ---Formats a number with thousands separators and decimal places. Works with both
-  ---numbers and numeric strings. If not specified, uses "," for thousands and "."
-  ---for decimal separator. Handles negative numbers and maintains decimal precision.
-  ---
-  ---@example
-  ---```lua
-  ---string.format_number(1234567.89)           -- "1,234,567.89"
-  ---string.format_number(-1234.56)             -- "-1,234.56"
-  ---string.format_number(1234567, ".", ",")    -- "1.234.567"
-  ---```
-  ---
-  ---@name format_number
-  ---@param number number|string - The number to format.
-  ---@param thousands string? - The thousands separator.
-  ---@param decimal string? - The decimal separator.
-  ---@return string # The formatted number.
-  function string.format_number(number, thousands, decimal) end
+    --- Replaces all occurrences of a pattern in a string.
+    ---
+    --- @param str string - The string to replace occurrences in.
+    --- @param pattern string - The pattern to replace.
+    --- @param replacement string - The replacement string.
+    --- @return string - The string with occurrences replaced.
+    --- @example
+    --- ```lua
+    --- string.replace("hello world", "o", "a")
+    --- -- "hella warld"
+    --- ```
+    function self.replace(str, pattern, replacement)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(pattern, "string", 2, false)
+      ___.v.type(replacement, "string", 3, false)
 
-  ---Removes whitespace characters from the beginning (left side) of a string.
-  ---Whitespace includes spaces, tabs, and newlines.
-  ---
-  ---@example
-  ---```lua
-  ---string.ltrim("  hello world  ")    -- "hello world  "
-  ---string.ltrim("\t\nhello")          -- "hello"
-  ---```
-  ---
-  ---@name ltrim
-  ---@param str string - The string to remove whitespace from.
-  ---@return string # The resulting string without whitespace on the left.
-  function string.ltrim(str) end
+      while string.find(str, pattern) do
+        str = string.gsub(str, pattern, replacement) or str
+      end
 
-  ---Converts a formatted number string back into a number. Handles thousands and
-  ---decimal separators, removing the thousands separators and converting the decimal
-  ---separator to a period if necessary.
-  ---
-  ---@example
-  ---```lua
-  ---string.parse_formatted_number("1,234,567.89")       -- 1234567.89
-  ---string.parse_formatted_number("1.234.567,89", ".", ",")  -- 1234567.89
-  ---```
-  ---
-  ---@name parse_formatted_number
-  ---@param str string - The string to parse.
-  ---@param thousands string? - The thousands separator.
-  ---@param decimal string? - The decimal separator.
-  ---@return number # The parsed number.
-  function string.parse_formatted_number(str, thousands, decimal) end
+      return str
+    end
 
-  ---Prepends a prefix to a string if it does not already start with that prefix.
-  ---Uses PCRE regex pattern matching to ensure accurate prefix detection.
-  ---
-  ---@example
-  ---```lua
-  ---string.prepend("world", "hello ")          -- "hello world"
-  ---string.prepend("hello world", "hello")     -- "hello world"
-  ---```
-  ---
-  ---@name prepend
-  ---@param str string - The string to prepend to.
-  ---@param prefix string - The prefix to prepend to the string.
-  ---@return string # The resulting string.
-  function string.prepend(str, prefix) end
+    --- Splits a string into a table of strings using PCRE regex. If no
+    --- delimiter is provided, it defaults to ".", which will split the string
+    --- into individual characters.
+    ---
+    --- @param str string - The string to split.
+    --- @param delimiter string - The regex delimiter to split the string by.
+    --- @return table - The split string.
+    --- @example
+    --- ```lua
+    --- string.split("hello world")
+    --- -- {"h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"}
+    ---
+    --- string.split("hello world", " ")
+    --- -- {"hello", "world"}
+    ---
+    --- string.split("hello.world", "\\.")
+    --- -- {"hello", "world"}
+    ---
+    --- string.split("hello world", "o")
+    --- -- {"hell", " w", "rld"}
+    --- ```
+    function self.split(str, delimiter)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(delimiter, "string", 2, true)
 
-  ---Performs pattern matching using reg_assoc with PCRE regex support. Associates
-  ---patterns with tokens and returns both the matched segments and their corresponding
-  ---token assignments.
-  ---
-  ---@example
-  ---```lua
-  ---local results, tokens = string.reg_assoc(
-  ---    "hello world",
-  ---    {"hello", "world"},
-  ---    {"greeting", "place"}
-  ---)
-  ---- results: {"hello", " ", "world"}
-  ---- tokens: {"greeting", -1, "place"}
-  ---```
-  ---
-  ---@name reg_assoc
-  ---@param text string - The text to search through
-  ---@param patterns table - The patterns to search for
-  ---@param tokens table - The tokens to replace the patterns with
-  ---@param default_token string? - The default token for unmatched text
-  ---@return table,table # The results table and token list
-  function string.reg_assoc(text, patterns, tokens, default_token) end
+      local t = {}
+      delimiter = delimiter or "."
 
-  ---Replaces all occurrences of a pattern in a string with a replacement string.
-  ---Continues replacing until no more matches are found to handle overlapping or
-  ---repeated patterns.
-  ---
-  ---@example
-  ---```lua
-  ---string.replace("hello world", "o", "a")     -- "hella warld"
-  ---string.replace("test", "t", "p")            -- "pesp"
-  ---```
-  ---
-  ---@name replace
-  ---@param str string - The string to replace the pattern in.
-  ---@param pattern string - The pattern to replace.
-  ---@param replacement string - The replacement string.
-  ---@return string # The resulting string.
-  function string.replace(str, pattern, replacement) end
+      for part in str:gmatch("[^" .. delimiter .. "]+") do
+        table.insert(t, part)
+      end
 
-  ---Removes whitespace characters from the end (right side) of a string.
-  ---Whitespace includes spaces, tabs, and newlines.
-  ---
-  ---@example
-  ---```lua
-  ---string.rtrim("  hello world  ")    -- "  hello world"
-  ---string.rtrim("hello\t\n")          -- "hello"
-  ---```
-  ---
-  ---@name rtrim
-  ---@param str string - The string to remove whitespace from.
-  ---@return string # The resulting string without whitespace on the right.
-  function string.rtrim(str) end
+      return t
+    end
 
-  ---Splits a string into a table of strings using PCRE regex. If no delimiter
-  ---is provided, it defaults to ".", which will split the string into individual
-  ---characters. The delimiter is treated as a regex pattern.
-  ---
-  ---@example
-  ---```lua
-  ---string.split("hello world")           -- {"h", "e", "l", "l", "o", " ", "w", "o", "r", "l", "d"}
-  ---string.split("hello world", " ")      -- {"hello", "world"}
-  ---string.split("hello.world", "\\.")    -- {"hello", "world"}
-  ---string.split("hello world", "o")      -- {"hell", " w", "rld"}
-  ---```
-  ---
-  ---@name split
-  ---@param str string - The string to split.
-  ---@param delimiter string? - The regex delimiter to split the string by.
-  ---@return string[] # The resulting array of strings.
-  function string.split(str, delimiter) end
+    --- Walks over a string or table, splitting the string with a PCRE regex
+    --- delimiter and returning an iterator.
+    ---
+    --- @param input string - The string to walk over.
+    --- @param delimiter string - The regex delimiter to split the string by.
+    --- @return function - The iterator function.
+    --- @example
+    --- ```lua
+    --- for i, part in string.walk("hello world") do
+    ---   print(i, part) -- prints 1=h, 2=e, 3=l, 4=l, 5=o, 6= , 7=w, 8=o, 9=r, 10=l, 11=d
+    --- end
+    --- ```
+    function self.walk(input, delimiter)
+      ___.v.type(input, "string", 1, false)
+      ___.v.type(delimiter, "string", 2, true)
 
-  ---Checks if a string starts with a given pattern using PCRE regex. If the pattern
-  ---doesn't already start with "^", it will be automatically prepended to ensure
-  ---matching at the start of the string.
-  ---
-  ---@example
-  ---```lua
-  ---string.starts_with("hello world", "hello")     -- true
-  ---string.starts_with("hello world", "world")     -- false
-  ---string.starts_with("test.lua", "^test")        -- true
-  ---```
-  ---
-  ---@name starts_with
-  ---@param str string - The string to check.
-  ---@param start string - The pattern to check for.
-  ---@return boolean # Whether the string starts with the pattern.
-  function string.starts_with(str, start) end
+      local data
+      if type(input) == "string" then
+        data = self.split(input, delimiter)
+      else
+        data = input
+      end
 
-  ---Removes all line breaks from a string, including both \r and \n characters.
-  ---Useful for converting multi-line text into a single line.
-  ---
-  ---@example
-  ---```lua
-  ---string.strip_linebreaks("hello\nworld")     -- "helloworld"
-  ---string.strip_linebreaks("hello\r\nworld")   -- "helloworld"
-  ---```
-  ---
-  ---@name strip_linebreaks
-  ---@param str string - The string to strip line breaks from.
-  ---@return string # The resulting string without line breaks.
-  function string.strip_linebreaks(str) end
+      return ___.table.walk(data)
+    end
 
-  ---Removes whitespace from both the beginning and end of a string.
-  ---Whitespace includes spaces, tabs, and newlines.
-  ---
-  ---@example
-  ---```lua
-  ---string.trim("  hello world  ")    -- "hello world"
-  ---string.trim("\t\nhello\n\t")      -- "hello"
-  ---```
-  ---
-  ---@name trim
-  ---@param str string - The string to trim.
-  ---@return string # The trimmed string.
-  function string.trim(str) end
+    --- Formats a number with thousands separators and decimal places.
+    --- If not specified, defaults to "," for thousands and "." for decimal.
+    ---
+    --- @example
+    --- ```lua
+    --- string.format_number(1234567.89)
+    --- -- "1,234,567.89"
+    --- ```
+    --- @param number string|number - The number to format (number or string)
+    --- @param thousands string - The thousands separator (optional, defaults to ",")
+    --- @param decimal string - The decimal separator (optional, defaults to ".")
+    --- @return string - The formatted number
+    function self.format_number(number, thousands, decimal)
+      ___.v.type(number, { "number|string" }, 1, false)
+      ___.v.type(thousands, "string", 2, true)
+      ___.v.type(decimal, "string", 3, true)
 
-  ---Creates an iterator that walks through a string character by character or by
-  ---split segments if a delimiter is provided. Returns index and value pairs.
-  ---
-  ---@example
-  ---```lua
-  ---for i, part in string.walk("hello world") do
-  ---  print(i, part)  -- prints: 1,"h" 2,"e" 3,"l" 4,"l" 5,"o" 6," " 7,"w" 8,"o" 9,"r" 10,"l" 11,"d"
-  ---end
-  ---
-  ---for i, part in string.walk("a,b,c", ",") do
-  ---  print(i, part)  -- prints: 1,"a" 2,"b" 3,"c"
-  ---end
-  ---```
-  ---
-  ---@name walk
-  ---@param input string - The string to walk through.
-  ---@param delimiter string? - The delimiter to split the string by.
-  ---@return function # The iterator function.
-  function string.walk(input, delimiter) end
+      -- Set defaults
+      thousands = thousands or ","
+      decimal = decimal or "."
 
-  ---Returns the index of the first occurrence of a pattern in a string.
-  ---This function uses PCRE regex to find the pattern.
-  ---
-  ---@example
-  ---```lua
-  ---string.index_of("hello world", "world")   -- 7
-  ---string.index_of("hello world", "o")       -- 4
-  ---string.index_of("hello world", "x")       -- nil
-  ---string.index_of("hello world", "[aeiou]") -- 2
-  ---string.index_of("hello world", "\\s")     -- 5
-  ---```
-  ---
-  ---@name index_of
-  ---@param str string - The string to search through.
-  ---@param pattern string - The pattern to search for.
-  ---@return number # The index of the pattern.
-  function string.index_of(str, pattern) end
-end
+      number = tonumber(number) or 0
+      local is_negative = not ___.number.positive(number)
+      number = math.abs(number)
+
+      -- Convert to string if needed
+      local numStr = tostring(number)
+
+      -- Split integer and decimal parts
+      local intPart, decPart = numStr:match("([^%.]*)%.?(.*)")
+
+      -- Add thousands separators to integer part
+      local formatted = ""
+      local length = #intPart
+
+      for i = 1, length do
+        if i > 1 and (length - i + 1) % 3 == 0 then
+          formatted = thousands .. formatted
+        end
+        formatted = intPart:sub(length - i + 1, length - i + 1) .. formatted
+      end
+
+      -- Add decimal part if it exists
+      if decPart and decPart ~= "" then
+        formatted = formatted .. decimal .. decPart
+      end
+
+      -- Restore negative sign if needed
+      if is_negative then formatted = "-" .. formatted end
+
+      return formatted
+    end
+
+    --- Parses a formatted number string back to a number.
+    ---
+    --- @param str string - The formatted number string.
+    --- @param thousands string - The thousands separator (optional, defaults to ",").
+    --- @param decimal string - The decimal separator (optional, defaults to ".").
+    --- @return number - The parsed number.
+    --- @example
+    --- ```lua
+    --- string.parse_formatted_number("1,234,567.89")
+    --- -- 1234567.89
+    --- ```
+    function self.parse_formatted_number(str, thousands, decimal)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(thousands, "string", 2, true)
+      ___.v.type(decimal, "string", 3, true)
+
+      thousands = thousands or ","
+      decimal = decimal or "."
+
+      -- Remove thousands separators
+      str = str:gsub(thousands, "") or str
+
+      -- Convert decimal separator to period if different
+      if decimal ~= "." then
+        str = str:gsub(decimal, ".") or str
+      end
+
+      -- Convert to number
+      return tonumber(str) or 0
+    end
+
+    --- Checks if a string starts with a given PCRE regex pattern.
+    --- If the pattern does not start with "^", it is prepended with "^".
+    ---
+    --- @param str string - The string to check.
+    --- @param start string - The pattern to check for.
+    --- @return boolean - Whether the string starts with the pattern.
+    --- @example
+    --- ```lua
+    --- string.starts_with("hello world", "hello")
+    --- -- true
+    --- ```
+    function self.starts_with(str, start)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(start, "string", 2, false)
+
+      start = string.sub(start, 1) == "^" and start or "^" .. start
+
+      return rex.match(str, start) ~= nil
+    end
+
+    --- Checks if a string ends with a given PCRE regex pattern.
+    --- If the pattern does not end with "$", it is appended with "$".
+    ---
+    --- @param str string - The string to check.
+    --- @param ending string - The pattern to check for.
+    --- @return boolean - Whether the string ends with the pattern.
+    --- @example
+    --- ```lua
+    --- string.ends_with("hello world", "world")
+    --- -- true
+    --- ```
+    function self.ends_with(str, ending)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(ending, "string", 2, false)
+
+      ending = string.sub(ending, 1) == "$" and ending or ending .. "$"
+
+      return rex.match(str, ending) ~= nil
+    end
+
+    --- Checks if a string contains a given PCRE regex pattern. The pattern
+    --- may not start with "^" or end with "$". For those, use
+    --- `string.starts_with` and `string.ends_with`.
+    ---
+    --- @param str string - The string to check.
+    --- @param pattern string - The pattern to check for.
+    --- @return boolean - Whether the string contains the pattern.
+    --- @example
+    --- ```lua
+    --- string.contains("hello world", "world")
+    --- -- true
+    --- ```
+    function self.contains(str, pattern)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(pattern, "string", 2, false)
+      ___.v.test(not self.starts_with(pattern, "^"), "Expected pattern to not start with ^", 2)
+      ___.v.test(not self.ends_with(pattern, "$"), "Expected pattern to not end with $", 2)
+
+      return rex.match(str, pattern) ~= nil
+    end
+
+    --- Appends a suffix to a string if it does not already end with the suffix.
+    ---
+    --- @param str string - The string to append to.
+    --- @param suffix string - The suffix to append.
+    --- @return string - The string with the suffix appended.
+    --- @example
+    --- ```lua
+    --- string.append("hello", " world")
+    --- -- "hello world"
+    --- ```
+    function self.append(str, suffix)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(suffix, "string", 2, false)
+
+      return self.ends_with(str, suffix) and str or str .. suffix
+    end
+
+    --- Prepends a prefix to a string if it does not already start with the prefix.
+    ---
+    --- @param str string - The string to prepend to.
+    --- @param prefix string - The prefix to prepend.
+    --- @return string - The string with the prefix prepended.
+    --- @example
+    --- ```lua
+    --- string.prepend("world", "hello ")
+    --- -- "hello world"
+    --- ```
+    function self.prepend(str, prefix)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(prefix, "string", 2, false)
+
+      return self.starts_with(str, prefix) and str or prefix .. str
+    end
+
+    --- Implementation of reg_assoc for Mudlet using rex PCRE support
+    --- @param text string - The text to search through
+    --- @param patterns table - The patterns to search for
+    --- @param tokens table - The tokens to replace the patterns with
+    --- @param default_token string - The default token to use if no pattern is found (optional, defaults to "")
+    --- @return table,table - A table of results and token list
+    --- @example
+    --- ```lua
+    --- string.reg_assoc("hello world", {"hello", "world"}, {"foo", "bar"})
+    --- -- {"foo", "bar"}
+    --- ```
+    function self.reg_assoc(text, patterns, tokens, default_token)
+      default_token = default_token or -1
+      local work = text
+
+      local results = {}
+      local token_list = {}
+
+
+      while #work > 0 do
+        local nearest_from, nearest_match, nearest_token = nil, nil, nil
+
+        for i, pattern in ipairs(patterns) do
+          local from, to = rex.find(work, pattern)
+          if from and to then
+            if not nearest_from or from < nearest_from then
+              nearest_from, nearest_match, nearest_token =
+                  from, work:sub(from, to), tokens[i] or default_token
+            end
+          end
+        end
+
+        local prematch = ""
+        local token = nearest_token or default_token
+        local match = nearest_match or work
+        nearest_from = nearest_from or #work
+        prematch = work:sub(1, nearest_from - 1 or nil)
+        print("Prematch = `" ..
+        tostring(prematch) .. "` with token `" .. tostring(token) .. "` and match `" .. tostring(match) .. "`")
+
+        work = work:sub(nearest_from + #match) or ""
+        --[[
+        if nearest_from then
+          token = nearest_token or default_token
+          match = nearest_match or work
+          prematch = ""
+        else
+          token = default_token
+          nearest_from = #work
+          match = work
+          work = ""
+          break
+        end
+
+        -- The text between 1 and the nearest match
+        local pre_match = work:sub(1, nearest_from - 1 or nil)
+--]]
+        -- Add it to the results
+        table.insert(results, pre_match)
+        table.insert(token_list, default_token)
+
+        if #match > 0 then
+          table.insert(results, match)
+          table.insert(token_list, token)
+        end
+      end
+
+      return results, token_list
+    end
+
+    function is_alpha(char)
+      ___.v.type(char, "string", 1, false)
+      ___.v.test(#char == 1, "Expected a single character", 1)
+
+      return rex.match(char, "^[a-zA-Z]$") ~= nil
+    end
+
+    function is_numeric(char)
+      ___.v.type(char, "string", 1, false)
+      ___.v.test(#char == 1, "Expected a single character", 1)
+
+      return rex.match(char, "^[0-9]$") ~= nil
+    end
+
+    function is_alphanumeric(char)
+      ___.v.type(char, "string", 1, false)
+      ___.v.test(#char == 1, "Expected a single character", 1)
+
+      return rex.match(char, "^[a-zA-Z0-9]$") ~= nil
+    end
+
+    function is_whitespace(char)
+      ___.v.type(char, "string", 1, false)
+      ___.v.test(#char == 1, "Expected a single character", 1)
+
+      return rex.match(char, "^%s$") ~= nil
+    end
+
+    function is_punctuation(char)
+      ___.v.type(char, "string", 1, false)
+      ___.v.test(#char == 1, "Expected a single character", 1)
+
+      return rex.match(char, "^[^a-zA-Z0-9%s]$") ~= nil
+    end
+
+    function is_uppercase(char)
+      ___.v.type(char, "string", 1, false)
+      ___.v.test(#char == 1, "Expected a single character", 1)
+
+      return rex.match(char, "^[A-Z]$") ~= nil
+    end
+
+    -- TODO: handle 1 or more
+    function is_lowercase(char)
+      ___.v.type(char, "string", 1, false)
+      ___.v.test(#char == 1, "Expected a single character", 1)
+
+      return rex.match(char, "^[a-z]$") ~= nil
+    end
+
+    function split_natural(str)
+      ___.v.type(str, "string", 1, false)
+
+      local resulit, current, is_numeric = {}, {}, false
+
+      local chars = {}
+      for c in self.walk(str) do
+        local new_is_num = self.is_numeric(c)
+
+        if i > 1 and new_is_num ~= is_num then
+          local chunk = table.concat(current)
+          if is_num then
+            table.push(result, tonumber(chunk))
+          else
+            table.insert(result, chunk)
+          end
+          current = {}
+        end
+
+        if #current > 0 then
+          local chunk = table.concat(current)
+          if is_num then
+            self.push(result, tonumber(chunk))
+          else
+            table.insert(result, chunk)
+          end
+        end
+      end
+    end
+
+    function natural_compare(a, b)
+      local a_parts = self.split_natural(a)
+      local b_parts = self.split_natural(b)
+
+      local len = math.min(#a_parts, #b_parts)
+
+      for i = 1, len do
+        local a_part, b_part = a_parts[i], b_parts[i]
+        local a_type, b_type = type(a_part), type(b_part)
+
+        if a_type == "number" and b_type == "number" then
+          if a_part ~= b_part then
+            return a_part < b_part
+          end
+        elseif a_type == "string" and b_type == "string" then
+          if a_part ~= b_part then
+            return a_part < b_part
+          end
+        else
+          local str_a, str_b = tostring(a_part), tostring(b_part)
+
+          if str_a ~= str_b then
+            return str_a < str_b
+          end
+        end
+      end
+
+      return #a_parts < #b_parts
+    end
+
+    function self.index_of(str, pattern)
+      ___.v.type(str, "string", 1, false)
+      ___.v.type(pattern, "string", 2, false)
+
+      return rex.find(str, pattern)
+    end
+  end
+})
+
+-- { "this", " ", "is", " ", "a", " ", "test" }
+-- { 1, nil, 1, nil, 1, nil, 1 }
+
+-- this is a thing that is num3rically unsoundh4444, and my favourite number is forty2

--- a/examples/source/lua/table.lua
+++ b/examples/source/lua/table.lua
@@ -1,643 +1,722 @@
----@meta TableClass
+local TableClass = Glu.glass.register({
+  name = "table",
+  class_name = "TableClass",
+  dependencies = {},
+  setup = function(___, self)
+    function self.n_cast(...)
+      if type(...) == "table" and self.indexed(...) then
+        return ...
+      end
 
-------------------------------------------------------------------------------
--- TableClass
-------------------------------------------------------------------------------
+      return { ... }
+    end
 
-if false then -- ensure that functions do not get defined
+    self.assure_indexed = self.n_cast
 
-  ---@class TableClass
+    function self.map(t, fn, ...)
+      ___.v.type(t, "table", 1, false)
+      ___.v.type(fn, "function", 2, false)
 
-  ---Adds a second associative table to a first associative table, merging the
-  ---second table into the first.
-  ---
-  ---@example
-  ---```lua
-  ---table.add({ a = 1 }, { b = 2 })
-  ----- { a = 1, b = 2 }
-  ---
-  ---table.add({ a = 1, b = 2 }, { b = 3, c = 4 })
-  ----- { a = 1, b = 3, c = 4 }
-  ---```
-  ---
-  ---@name add
-  ---@param table1 table - The table to add the value to.
-  ---@param table2 table - The table to add to the first table.
-  ---@return table # The first table with the second table added.
-  function table.add(table1, table2) end
+      local result = {}
+      for k, v in pairs(t) do
+        result[k] = fn(k, v, ...)
+      end
+      return result
+    end
 
-  ---Allocates a new table with given an initial indexed table and a
-  ---specification for the new table.
-  ---
-  ---The specification can be:
-  ---* another indexed table, in which case the new table will be created with
-  ---  the same values as the source table, but with the values in the spec table
-  ---  applied to each corresponding value in the source table. The second table
-  ---  must have the same number of elements as the source table.
-  ---* a function, in which case the function will be applied to each value in
-  ---  the source table to produce the values in the new table.
-  ---* a single type, in which case all values in the new table will be of
-  ---  that type
-  ---
-  ---@example
-  ---```lua
-  ---table.allocate({"a", "b", "c"}, "x")
-  ----- {a = "x", b = "x", c = "x"}
-  ---
-  ---table.allocate({"a","b","c"}, {1, 2, 3})
-  ----- {a = 1, b = 2, c = 3}
-  ---
-  ---table.allocate({ "a", "b", "c" }, function(k, v)
-  ---  return string.byte(v)
-  ---end)
-  ----- {a = 97, b = 98, c = 99}
-  ---```
-  ---@name allocate
-  ---@param source table - The table to copy.
-  ---@param spec table - The specification for the new table.
-  ---@return table # The new table.
-  function table.allocate(source, spec) end
+    function self.values(t)
+      ___.v.type(t, "table", 1, false)
 
-  ---Returns true if the table is associative, false otherwise.
-  ---
-  ---@example
-  ---```lua
-  ---table.associative({ a = 1, b = 2 })
-  ----- true
-  ---
-  ---table.associative({ 1, 2, 3 })
-  ----- false
-  ---```
-  ---
-  ---@name associative
-  ---@param t table - The table to check.
-  ---@return boolean # True if the table is associative, false otherwise.
-  function table.associative(t) end
+      local result = {}
+        for _, v in pairs(t) do
+        result[#result + 1] = v
+      end
+      return result
+    end
 
-  ---Returns a table of tables, each containing a slice of the original table
-  ---of specified size. If there are not enough elements to fill the last
-  ---chunk, the last chunk will contain the remaining elements.
-  ---
-  ---@example
-  ---```lua
-  ---table.chunk({1, 2, 3, 4, 5}, 2)
-  ----- {{1, 2}, {3, 4}, {5}}
-  ---```
-  ---
-  ---@name chunk
-  ---@param t table - The table to chunk.
-  ---@param size number - The size of each chunk.
-  ---@return table # A table of tables, each containing a slice of the original table.
-  function table.chunk(t, size) end
+    function self.n_uniform(t, typ)
+      ___.v.type(t, "table", 1, false)
+      ___.v.indexed(t, 1, false)
+      ___.v.type(typ, "string", 2, true)
 
-  ---Creates a new table by concatenating the original table with any
-  ---additional arrays and/or values. If the arguments contains tables, they
-  ---will be concatenated with the original table. Otherwise, the values will
-  ---be added to the end of the original table.
-  ---@example
-  ---```lua
-  ---table.concat({1}, 2, {3}, {{4}})
-  ----- {1, 2, 3, {4}}
-  ---```
-  ---
-  ---@name concat
-  ---@param tbl table - The first table to concatenate.
-  ---@param ... any - Additional tables and/or values to concatenate.
-  ---@return table # A new table containing the concatenated tables.
-  function table.concat(tbl, ...) end
+      typ = typ or type(t[1])
 
-  ---Drops the first n elements from an indexed table.
-  ---
-  ---@name drop
-  ---@param tbl table - The table to drop elements from.
-  ---@param n number - The number of elements to drop.
-  ---@return table # A new table with the first n elements removed.
-  function table.drop(tbl, n) end
+      for _, v in pairs(t) do
+        if type(v) ~= typ then
+          return false
+        end
+      end
 
-  ---Drops the last n elements from an indexed table.
-  ---
-  ---@name drop_right
-  ---@param tbl table - The table to drop elements from.
-  ---@param n number - The number of elements to drop.
-  ---@return table # A new table with the last n elements removed.
-  function table.drop_right(tbl, n) end
+      return true
+    end
 
-  ---Returns a random element from the keys of a table, with each value
-  ---representing a weight.
-  ---
-  ---@example
-  ---```lua
-  ---table.element_of_weighted({ [1] = 10, [2] = 20, [3] = 70 })
-  ----- 3
-  ---```
-  ---
-  ---@name element_of_weighted
-  ---@param list table - The table to choose an element from.
-  ---@return any # A random element from the table.
-  function table.element_of_weighted(list) end
+    function self.n_distinct(t)
+      ___.v.indexed(t, 1, false)
 
-  ---Returns a random element from an indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---table.element_of({1, 2, 3})
-  ----- 2
-  ---```
-  ---
-  ---@name element_of
-  ---@param list table - The table to choose an element from.
-  ---@return any # A random element from the table.
-  function table.element_of(list) end
+      local result, seen = {}, {}
+      for _, v in ipairs(t) do
+        if not seen[v] then
+          seen[v] = true
+          result[#result + 1] = v
+        end
+      end
+      return result
+    end
 
-  ---Fills an indexed table with a value.
-  ---
-  ---If the start index is not provided, it will fill from the beginning of the
-  ---table. If the stop index is not provided, it will fill to the end of the
-  ---table.
-  ---
-  ---@example
-  ---```lua
-  ---table.fill({1, 2, 3, 4, 5}, "x")
-  ----- {"x", "x", "x", "x", "x"}
-  ---
-  ---table.fill({1, 2, 3, 4, 5}, "x", 2)
-  ----- {1, "x", "x", 4, 5}
-  ---
-  ---table.fill({1, 2, 3, 4, 5}, "x", 2, 4)
-  ----- {1, "x", "x", "x", 5}
-  ---```
-  ---
-  ---@name fill
-  ---@param tbl table - The table to fill.
-  ---@param value any - The value to fill the table with.
-  ---@param start number? - The start index to fill.
-  ---@param stop number? - The stop index to fill.
-  ---@return table # The filled table.
-  function table.fill(tbl, value, start, stop) end
+    function self.pop(t)
+      ___.v.type(t, "table", 1, false)
+      ___.v.indexed(t, 1, false)
+      return table.remove(t, #t)
+    end
 
-  ---Returns the index of the first element in a table that satisfies a
-  ---predicate function.
-  ---
-  ---@example
-  ---```lua
-  ---table.find({1, 2, 3, 4, 5}, function(v) return v > 3 end)
-  ----- 4
-  ---```
-  ---
-  ---@name find
-  ---@param tbl table - The table to find the index of the first element in.
-  ---@param fn function - The predicate function to satisfy.
-  ---@return number|nil # The index of the first element that satisfies the predicate function, or nil if no element satisfies the predicate.
-  function table.find(tbl, fn) end
+    function self.push(t, v)
+      ___.v.type(t, "table", 1, false)
+      ___.v.type(v, "any", 2, false)
+      ___.v.indexed(t, 1, false)
+      table.insert(t, v)
 
+      return #t
+    end
 
-  ---Returns the index of the last element in a table that satisfies a
-  ---predicate function.
-  ---
-  ---@example
-  ---```lua
-  ---table.find_last({1, 2, 3, 4, 5}, function(v) return v > 3 end)
-  ----- 4
-  ---```
-  ---
-  ---@name find_last
-  ---@param tbl table - The table to find the index of the last element in.
-  ---@param fn function - The predicate function to satisfy.
-  ---@return number? # The index of the last element that satisfies the predicate function, or nil if no element satisfies the predicate.
-  function table.find_last(tbl, fn) end
+    function self.unshift(t, v)
+      ___.v.type(t, "table", 1, false)
+      ___.v.type(v, "any", 2, false)
+      ___.v.indexed(t, 1, false)
+      table.insert(t, 1, v)
 
-  ---Flattens a table of tables into a single table recursively.
-  ---
-  ---@example
-  ---```lua
-  ---table.flatten_deeply({1, {2, {3, {4}}, 5}})
-  ----- {1, 2, 3, 4, 5}
-  ---```
-  ---
-  ---@name flatten_deeply
-  ---@param tbl table - The table to flatten recursively.
-  ---@return table # A new table containing the flattened table.
-  function table.flatten_deeply(tbl) end
+      return #t
+    end
 
-  ---Flattens a table of tables into a single table.
-  ---
-  ---@example
-  ---```lua
-  ---table.flatten({1, {2, {3, {4}}, 5}})
-  ----- {1, 2, 3, 4, 5}
-  ---```
-  ---
-  ---@name flatten
-  ---@param tbl table - The table to flatten.
-  ---@return table # A new table containing the flattened table.
-  function table.flatten(tbl) end
+    function self.shift(t)
+      ___.v.type(t, "table", 1, false)
+      ___.v.indexed(t, 1, false)
+      return table.remove(t, 1)
+    end
 
-  ---Returns a table of the functions in a table.
-  ---
-  ---@example
-  ---```lua
-  ---table.functions({a = 1, b = 2, c = end})
-  ----- {c = function()}
-  ---```
-  ---
-  ---@name functions
-  ---@param tbl table - The table to get the functions from.
-  ---@param inherited boolean? - Whether to include inherited functions.
-  ---@return table # A table of the functions in the table.
-  function table.functions(tbl, inherited) end
+    function self.allocate(source, spec)
+      local spec_type = type(spec)
+      ___.v.type(source, "table", 1, false)
+      ___.v.not_empty(source, 1, false)
+      ___.v.indexed(source, 1, false)
+      if spec_type == ___.TYPE.TABLE then
+        ___.v.indexed(spec, 2, false)
+        assert(#source == #spec, "Expected source and spec to have the same number of elements")
+      elseif spec_type == ___.TYPE.FUNCTION then
+        ___.v.type(spec, "function", 2, false)
+      end
 
-  ---Returns true if an indexed table includes a value, false otherwise.
-  ---
-  ---@example
-  ---```lua
-  ---table.includes({1, 2, 3}, 2)
-  ----- true
-  ---```
-  ---
-  ---@name includes
-  ---@param tbl table - The table to check.
-  ---@param value any - The value to check for.
-  ---@return boolean # True if the table includes the value, false otherwise.
-  function table.includes(tbl, value) end
+      local result = {}
 
-  ---Returns true if a table is indexed, false otherwise.
-  ---
-  ---@example
-  ---```lua
-  ---table.indexed({1, 2, 3})
-  ----- true
-  ---
-  ---table.indexed({ a = 1, b = 2 })
-  ----- false
-  ---```
-  ---
-  ---@name indexed
-  ---@param t table - The table to check.
-  ---@return boolean # True if the table is indexed, false otherwise.
-  function table.indexed(t) end
+      if spec_type == ___.TYPE.TABLE then
+        for i = 1, #spec do
+          result[source[i]] = spec[i]
+        end
+      elseif spec_type == ___.TYPE.FUNCTION then
+        for i = 1, #source do
+          result[source[i]] = spec(i, source[i])
+        end
+      else
+        for i = 1, #source do
+          result[source[i]] = spec
+        end
+      end
 
-  ---Returns an indexed table with the last element removed from the original
-  ---indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---table.initial({1, 2, 3, 4, 5})
-  ----- {1, 2, 3, 4}
-  ---```
-  ---
-  ---@name initial
-  ---@param tbl table - The table to remove the last element from.
-  ---@return table # A new table with the last element removed.
-  function table.initial(tbl) end
+      return result
+    end
 
-  ---Returns true if a table is an object, false otherwise.
-  ---
-  ---@example
-  ---```lua
-  ---local object1 = {1,2,3}
-  ---local object2 = {}
-  ---setmetatable(object2, { __index = object1 })
-  ---
-  ---table.object(object1)
-  ----- false
-  ---table.object(object2)
-  ----- true
-  ---```
-  ---
-  ---@name object
-  ---@param tbl table - The table to check.
-  ---@return boolean # True if the table is an object, false otherwise.
-  function table.object(tbl) end
+    function self.indexed(t)
+      ___.v.type(t, "table", 1, false)
 
-  ---Returns a new table with a function applied to each element of the original
-  ---table, transforming each element into a new value.
-  ---
-  ---@example
-  ---```lua
-  ---table.map({1, 2, 3}, function(v) return v * 2 end)
-  ----- {2, 4, 6}
-  ---```
-  ---
-  ---@name map
-  ---@param t table - The table to map over.
-  ---@param fn function - The function to map over the table.
-  ---@param ... any - Additional arguments to pass to the function.
-  ---@return table # A new table with the function applied to each element.
-  function table.map(t, fn, ...) end
+      local index = 1
+      for k in pairs(t) do
+        if k ~= index then
+          return false
+        end
+        index = index + 1
+      end
+      return true
+    end
 
-  ---Appends or inserts a second indexed table into a first indexed table at
-  ---a specified index.
-  ---
-  ---If the index is not provided, the second table is appended to the end of
-  ---the first table. If the index is provided, the second table is inserted into
-  ---the first table at the specified index.
-  ---
-  ---@example
-  ---```lua
-  ---table.n_add({1, 2, 3}, {4, 5, 6})
-  ----- {1, 2, 3, 4, 5, 6}
-  ---
-  ---table.n_add({1, 2, 3}, {4, 5, 6}, 2)
-  ----- { 1, 4, 5, 6, 2, 3 }
-  ---```
-  ---
-  ---@name n_add
-  ---@param tbl1 table - The first table to add the value to.
-  ---@param tbl2 table - The second table to add to the first table.
-  ---@param index number? - The index to add the second table to.
-  ---@return table # The first table with the second table added.
-  function table.n_add(tbl1, tbl2, index) end
+    function self.associative(t)
+      ___.v.type(t, "table", 1, false)
 
-  ---Casts a value to an indexed table if it is not already one.
-  ---
-  ---@example
-  ---```lua
-  ---table.n_cast(1)
-  ----- {1}
-  ---
-  ---table.n_cast({1, 2, 3})
-  ----- {1, 2, 3}
-  ---```
-  ---
-  ---@name n_cast
-  ---@param ... any - The value to cast.
-  ---@return table # A new indexed table with the value or the value itself if it is already indexed.
-  function table.n_cast(...) end
+      for k, _ in pairs(t) do
+        if type(k) ~= "number" or k % 1 ~= 0 or k <= 0 then
+            return true
+        end
+      end
+      return false
+    end
 
-  ---Returns a new table with the distinct elements of an indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---table.n_distinct({1, 2, 3, 2, 1})
-  ----- {1, 2, 3}
-  ---```
-  ---
-  ---@name n_distinct
-  ---@param t table - The table to get the distinct elements from.
-  ---@return table # A new table with the distinct elements.
-  function table.n_distinct(t) end
+    function self.reduce(t, fn, initial)
+      ___.v.indexed(t, 1, false)
+      ___.v.type(fn, "function", 2, false)
+      ___.v.type(initial, "any", 3, false)
 
-  ---Returns true or false if all elements in an indexed table are of the same
-  ---type. If a type is not provided, it will check if all elements are of the
-  ---same type as the first element in the table.
-  ---
-  ---@example
-  ---```lua
-  ---table.n_uniform({1, 2, 3}, "number")
-  ----- true
-  ---```
-  ---
-  ---@name n_uniform
-  ---@param t table - The table to check.
-  ---@param typ string? - The type to check for.
-  ---@return boolean # True if all elements are of the same type, false otherwise.
-  function table.n_uniform(t, typ) end
+      local acc = initial
+      for k, v in pairs(t) do
+        acc = fn(acc, v, k)
+      end
+      return acc
+    end
 
-  ---Creates a new table with weak references. Valid options are "v" for
-  ---weak values, "k" for weak keys, and "kv" or "vk" for weak keys and
-  ---values.
-  ---
-  ---@example
-  ---```lua
-  ---table.new_weak("v")
-  ----- A table with weak value references
-  ---```
-  ---
-  ---@name new_weak
-  ---@param opt string? - The reference type.
-  ---@return table # A new table with weak references.
-  function table.new_weak(opt) end
+    function self.slice(t, start, stop)
+      ___.v.indexed(t, 1, false)
+      ___.v.type(start, "number", 2, false)
+      ___.v.type(stop, "number", 3, true)
+      ___.v.test(start >= 1, 2, false)
+      ___.v.test(table.size(t) >= start, 2, false)
+      ___.v.test(stop and stop >= start, 3, true)
 
-  ---Removes and returns the last element of an indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---local sample = {1, 2, 3}
-  ---table.pop(sample)
-  ----- 3
-  ----- sample = {1, 2}
-  ---```
-  ---
-  ---@name pop
-  ---@param t table - The table to remove the last element from.
-  ---@return any # The last element of the table.
-  function table.pop(t) end
+      if not stop then
+        stop = #t
+      end
 
-  ---Returns a table of the properties of a table. This function only returns
-  ---the properties of the table itself, not the properties of any metatables,
-  ---and no functions.
-  ---
-  ---If the inherited parameter is true, it will include the properties of any
-  ---metatables.
-  ---
-  ---@example
-  ---```lua
-  ---table.properties({a = 1, b = 2})
-  ----- {a = 1, b = 2}
-  ---```
-  ---
-  ---@name properties
-  ---@param tbl table - The table to get the properties from.
-  ---@param inherited boolean? - Whether to include inherited properties.
-  ---@return table # A table of the properties of the table.
-  function table.properties(tbl, inherited) end
+      local result = {}
+      for i = start, stop do
+        result[#result + 1] = t[i]
+      end
+      return result
+    end
 
-  ---Adds a value to the end of an indexed table, returning the new length of
-  ---the table.
-  ---
-  ---@example
-  ---```lua
-  ---table.push({1, 2, 3}, 4)
-  ----- 4
-  ---```
-  ---
-  ---@name push
-  ---@param t table - The table to append the value to.
-  ---@param v any - The value to append to the table.
-  ---@return number # The new length of the table.
-  function table.push(t, v) end
+    function self.remove(t, start, stop)
+      ___.v.indexed(t, 1, false)
+      ___.v.type(start, "number", 2, false)
+      ___.v.type(stop, "number", 3, true)
+      ___.v.test(start >= 1, 2, false)
+      ___.v.test(table.size(t) >= start, 2, false)
+      ___.v.test(stop and stop >= start, 3, true)
 
-  ---Reduces an indexed table to a single value using a reducer function.
-  ---
-  ---@example
-  ---```lua
-  ---table.reduce({1, 2, 3}, function(acc, v) return acc + v end, 0)
-  ----- 6
-  ---```
-  ---
-  ---@name reduce
-  ---@param t table - The table to reduce.
-  ---@param fn function - The reducer function.
-  ---@param initial any? - The initial value.
-  ---@return any # The reduced value.
-  function table.reduce(t, fn, initial) end
+      local snipped = {}
+      if not stop then stop = start end
+      local count = stop - start + 1
+      for i = 1, count do
+        table.insert(snipped, table.remove(t, start))
+      end
+      return t, snipped
+    end
 
-  ---Removes and returns a slice of a table from the start index to the stop
-  ---index. If the stop index is not provided, it will only remove the element
-  ---at the start index. A second return value is also provided containing the
-  ---removed slice.
-  ---
-  ---@example
-  ---```lua
-  ---table.remove({1, 2, 3, 4, 5}, 2, 4)
-  ----- {1, 5}
-  ----- {2, 3, 4}
-  ---
-  ---table.remove({1, 2, 3, 4, 5}, 2)
-  ----- {1, 3, 4, 5}
-  ----- {2}
-  ---```
-  ---
-  ---@name remove
-  ---@param t table - The table to remove the slice from.
-  ---@param start number - The start index of the slice.
-  ---@param stop number? - The stop index of the slice.
-  ---@return table # A new table containing the removed slice.
-  function table.remove(t, start, stop) end
+    function self.chunk(t, size)
+      ___.v.indexed(t, 1, false)
+      ___.v.type(size, "number", 2, false)
 
-  ---Reverses an indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---table.reverse({1, 2, 3})
-  ----- {3, 2, 1}
-  ---```
-  ---
-  ---@name reverse
-  ---@param tbl table - The table to reverse.
-  ---@return table # A new reversed table.
-  function table.reverse(tbl) end
+      local result = {}
+      for i = 1, #t, size do
+        result[#result + 1] = ___.slice(t, i, i + size - 1)
+      end
+      return result
+    end
 
-  ---Removes and returns the first element of an indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---table.shift({1, 2, 3})
-  ----- 1
-  ---```
-  ---
-  ---@name shift
-  ---@param t table - The table to remove the first element from.
-  ---@return any # The first element of the table.
-  function table.shift(t) end
+    function self.concat(tbl, ...)
+      ___.v.indexed(tbl, 1, false)
 
-  ---Returns a slice of an indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---table.slice({1, 2, 3, 4, 5}, 2, 4)
-  ----- {2, 3, 4}
-  ---```
-  ---
-  ---@name slice
-  ---@param t table - The table to slice.
-  ---@param start number? - The start index.
-  ---@param stop number? - The stop index.
-  ---@return table # A new table with the slice.
-  function table.slice(t, start, stop) end
+      local args = { ... }
 
-  ---Returns a new table with the unique elements of an indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---table.uniq({1, 2, 3, 2, 1})
-  ----- {1, 2, 3}
-  ---```
-  ---
-  ---@name uniq
-  ---@param tbl table - The table to get the unique elements from.
-  ---@return table # A new table with the unique elements.
-  function table.uniq(tbl) end
+      for _, tbl_value in ipairs(args) do
+        if type(tbl_value) == "table" then
+          for _, value in ipairs(tbl_value) do
+            table.insert(tbl, value)
+          end
+        else
+          table.insert(tbl, tbl_value)
+        end
+      end
 
-  ---Adds a value to the beginning of an indexed table.
-  ---
-  ---@example
-  ---```lua
-  ---table.unshift({1, 2, 3}, 4)
-  ----- 4
-  ---```
-  ---
-  ---@name unshift
-  ---@param t table - The table to add the value to.
-  ---@param v any - The value to add to the table.
-  ---@return number # The new length of the table.
-  function table.unshift(t, v) end
+      return tbl
+    end
 
-  ---Unzips a table of tables into a table of tables. The index of the new
-  ---sub-tables will be the same as the index of the sub-tables in the original
-  ---table.
-  ---
-  ---@example
-  ---```lua
-  ---local combined = {{"John", 25}, {"Jane", 30}, {"Jim", 35}}
-  ---local names, ages = unpack(table.unzip(combined))
-  ----- names = {"John", "Jane", "Jim"}
-  ----- ages = {25, 30, 35}
-  ---```
-  ---
-  ---@name unzip
-  ---@param tbl table - The table to unzip.
-  ---@return table # A table of tables.
-  function table.unzip(tbl) end
+    function self.drop(tbl, n)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(n, "number", 2, false)
+      ___.v.test(n >= 1, 2, false)
+      return self.slice(___, tbl, n + 1)
+    end
 
-  ---Returns an indexed table with the values of an associative table.
-  ---
-  ---@example
-  ---```lua
-  ---table.values({a = 1, b = 2})
-  ----- {1, 2}
-  ---```
-  ---
-  ---@name values
-  ---@param t table - The table to get the values from.
-  ---@return table # An indexed table with the values.
-  function table.values(t) end
+    function self.drop_right(tbl, n)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(n, "number", 2, false)
+      ___.v.test(n >= 1, 2, false)
+      return self.slice(___, tbl, 1, #tbl - n)
+    end
 
-  ---Returns an iterator function that can be used to walk over an indexed
-  ---table.
-  ---
-  ---@example
-  ---```lua
-  ---table.walk({1, 2, 3}, function(v) print(v) end)
-  ----- 1
-  ----- 2
-  ----- 3
-  ---```
-  ---
-  ---@name walk
-  ---@param tbl table - The table to walk over.
-  ---@return function # An iterator function.
-  function table.walk(tbl) end
+    function self.fill(tbl, value, start, stop)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(value, "any", 2, false)
+      ___.v.type(start, "number", 3, true)
+      ___.v.type(stop, "number", 4, true)
+      ___.v.test(start and start >= 1, value, 3, true)
+      ___.v.test(stop and stop >= start, value, 4, true)
 
-  ---Returns a new table with weak references. Valid options are "v" for
-  ---weak values, "k" for weak keys, and "kv" or "vk" for weak keys and
-  ---values.
-  ---
-  ---@example
-  ---```lua
-  ---table.weak("v")
-  ----- A table with weak value references
-  ---```
-  ---
-  ---@name weak
-  ---@param opt string? - The reference type.
-  ---@return table # A new table with weak references.
-  function table.weak(opt) end
+      for i = start or 1, stop or #tbl do
+        tbl[i] = value
+      end
+      return tbl
+    end
 
-  ---Zips multiple tables together. The tables must all be of the same length.
-  ---
-  ------ @example
-  ---```lua
-  ---local names = {"John", "Jane", "Jim"}
-  ---local ages = {25, 30, 35}
-  ---
-  ---table.zip(names, ages)
-  ----- {{"John", 25}, {"Jane", 30}, {"Jim", 35}}
-  ---```
-  ---
-  ---@name zip
-  ---@param ... table - The tables to zip together.
-  ---@return table # A new table containing the zipped tables.
-  function table.zip(...) end
+    function self.find(tbl, fn)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(fn, "function", 2, false)
 
-end
+      for i = 1, #tbl do
+        if fn(i, tbl[i]) then
+          return i
+        end
+      end
+      return nil
+    end
+
+    function self.find_last(tbl, fn)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(fn, "function", 2, false)
+
+      for i = #tbl, 1, -1 do
+        if fn(i, tbl[i]) then
+          return i
+        end
+      end
+      return nil
+    end
+
+    function self.flatten(tbl)
+      ___.v.indexed(tbl, 1, false)
+
+      local result = {}
+      for _, v in ipairs(tbl) do
+        if type(v) == "table" then
+          ___.concat(result, v)
+        else
+          table.insert(result, v)
+        end
+      end
+
+      return result
+    end
+
+    function self.flatten_deeply(tbl)
+      ___.v.indexed(tbl, 1, false)
+
+      local result = {}
+      for _, v in ipairs(tbl) do
+        if type(v) == "table" then
+          self.concat(result, self.flatten_deeply(v))
+        else
+          table.insert(result, v)
+        end
+      end
+
+      return result
+    end
+
+    function self.initial(tbl)
+      ___.v.indexed(tbl, 1, false)
+      return self.slice(___, tbl, 1, #tbl - 1)
+    end
+
+    function self.pull(tbl, ...)
+      ___.v.indexed(tbl, 1, false)
+
+      local args = { ... }
+      if #args == 0 then return tbl end
+
+      local removeSet = {}
+      for _, value in ipairs(args) do
+        removeSet[value] = true
+      end
+
+      for i = #tbl, 1, -1 do
+        if removeSet[tbl[i]] then
+          table.remove(tbl, i)
+        end
+      end
+
+      return tbl
+    end
+
+    function self.reverse(tbl)
+      ___.v.indexed(tbl, 1, false)
+
+      local len, midpoint = #tbl, math.floor(#tbl / 2)
+      for i = 1, midpoint do
+        tbl[i], tbl[len - i + 1] = tbl[len - i + 1], tbl[i]
+      end
+      return tbl
+    end
+
+    function self.uniq(tbl)
+      ___.v.indexed(tbl, 1, false)
+
+      local seen = {}
+      local writeIndex = 1
+
+      for readIndex = 1, #tbl do
+        local value = tbl[readIndex]
+        if not seen[value] then
+          seen[value] = true
+          tbl[writeIndex] = value
+          writeIndex = writeIndex + 1
+        end
+      end
+
+      -- Remove excess elements beyond writeIndex
+      for i = #tbl, writeIndex, -1 do
+        tbl[i] = nil
+      end
+
+      return tbl
+    end
+
+    function self.unzip(tbl)
+      ___.v.indexed(tbl, 1, false)
+
+      local size_of_table = #tbl
+      -- Ensure that all sub-tables are of the same length
+      local size_of_elements = #tbl[1]
+      for _, t in ipairs(tbl) do ___.v.test(size_of_elements == #t, t, 1, false) end
+
+      local num_new_sub_tables = size_of_elements -- yes, this is redundant, but it's more readable
+      local new_sub_table_size = size_of_table -- this is the size of the sub-tables
+      local result = {}
+
+      for i = 1, num_new_sub_tables do
+        result[i] = {}
+      end
+
+      for _, source_table in ipairs(tbl) do
+        for i, value in ipairs(source_table) do
+          table.insert(result[i], value)
+        end
+      end
+
+      return result
+    end
+
+    function self.new_weak(opt)
+      ___.v.test(rex.match(opt, "^(k?v?|v?k?)$"), opt, 1, true)
+
+      opt = opt or "v"
+
+      return setmetatable({}, { __mode = opt })
+    end
+
+    function self.weak(tbl)
+      ___.v.type(tbl, "table", 1, false)
+      return getmetatable(tbl) and getmetatable(tbl).__mode ~= nil
+    end
+
+    function self.zip(...)
+      local tbls = { ... }
+      local results = {}
+
+      local size = #tbls[1]
+      for _, t in ipairs(tbls) do ___.v.test(size == #t, t, 1, false) end
+
+      for i = 1, size do
+        results[i] = {}
+        for _, t in ipairs(tbls) do
+          table.insert(results[i], t[i])
+        end
+      end
+      return results
+    end
+
+    function self.includes(tbl, value)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(value, "any", 2, false)
+      return table.index_of(tbl, value) ~= nil
+    end
+
+    local function collect_tables(tbl, extending)
+      -- Check if the table is a valid object with a metatable and an __index field
+      ___.v.object(tbl, 1, false)
+      ___.v.type(extending, "boolean", 2, true)
+
+      -- Set-like table to track visited tables
+      local visited = {}
+      local tables = {}
+
+      local function add_table(t)
+        if not visited[t] then
+          table.insert(tables, t)
+          visited[t] = true
+        end
+      end
+
+      -- Start by adding the main table
+      add_table(tbl)
+
+      if extending then
+        local mt = getmetatable(tbl)
+        while mt and mt.__index do
+          local extendingTbl = mt.__index
+          if type(extendingTbl) == "table" then
+            add_table(extendingTbl)
+          end
+          mt = getmetatable(extendingTbl)
+        end
+      end
+
+      return tables
+    end
+
+    local function get_types(tbl, test)
+      ___.v.type(tbl, "table", 1, false)
+      ___.v.type(test, "function", 2, false)
+
+      local keys = table.keys(tbl)
+      keys = table.n_filter(keys, function(k) return test(tbl, k) end) or {}
+      return keys
+    end
+
+    local function assemble_results(tables, test)
+      local result = {}
+      for _, t in ipairs(tables) do
+        local keys = get_types(t, test) or {}
+        for _, k in ipairs(keys) do
+          if not ___.table.includes(result, k) then
+            table.insert(result, k)
+          end
+        end
+      end
+      return result
+    end
+
+    function self.functions(tbl, extending)
+      ___.v.object(tbl, 1, false)
+      ___.v.type(extending, "boolean", 2, true)
+
+      local tables = collect_tables(tbl, extending) or {}
+      local test = function(t, k) return type(t[k]) == "function" end
+
+      return assemble_results(tables, test)
+    end
+    -- Alias for functions
+    self.methods = self.functions
+
+    function self.properties(tbl, extending)
+      ___.v.object(tbl, 1, false)
+      ___.v.type(extending, "boolean", 2, true)
+
+      local tables = collect_tables(tbl, extending) or {}
+      local test = function(t, k) return type(t[k]) ~= "function" end
+
+      return assemble_results(tables, test)
+    end
+
+    function self.object(tbl)
+      ___.v.type(tbl, "table", 1, false)
+      return tbl.object == true
+    end
+
+    function self.add(tbl, value)
+      ___.v.associative(tbl, 1, false)
+      ___.v.associative(value, 2, false)
+
+      for k, v in pairs(value) do
+        tbl[k] = v
+      end
+
+      return tbl
+    end
+
+    function self.n_add(tbl1, tbl2, index)
+      ___.v.indexed(tbl1, 1, false)
+      ___.v.indexed(tbl2, 2, false)
+      ___.v.range(index, 1, #tbl1 + 1, 3, true)
+
+      -- We are not adding +1 to the end index because we will be doing +1
+      -- in the loop below
+      index = index or #tbl1 + 1
+
+      for i = 1, #tbl2 do
+        table.insert(tbl1, index + i - 1, tbl2[i])
+      end
+
+      return tbl1
+    end
+
+    function self.walk(tbl)
+      ___.v.indexed(tbl, 1, false)
+
+      local i = 0
+      return function()
+        i = i + 1
+        if tbl[i] then return i, tbl[i] end
+      end
+    end
+
+    function self.element_of(list)
+      ___.v.type(list, "table", 1, false)
+
+      local max = #list
+      return list[math.random(max)]
+    end
+
+    function self.element_of_weighted(list)
+      ___.v.type(list, "table", 1, false)
+
+      local total = 0
+      for _, value in pairs(list) do
+        total = total + value
+      end
+
+      local random = math.random(total)
+
+      for key, value in pairs(list) do
+        random = random - value
+        if random <= 0 then
+          return key
+        end
+      end
+    end
+
+    local assure_equality_function = function(condition)
+      if type(condition) ~= "function" then
+        condition = function(_, k) return k == condition end
+      end
+      return condition
+    end
+
+    function self.all(tbl, condition)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(condition, "any", 2, false)
+
+      local count = 0
+
+      condition = assure_equality_function(condition)
+
+      local result = table.n_filter(tbl, condition)
+      if result then
+        count = #result
+      end
+
+      return count == #tbl
+    end
+
+    function self.some(tbl, condition)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(condition, "any", 2, false)
+
+      condition = assure_equality_function(condition)
+
+      return table.n_filter(tbl, condition) ~= nil
+    end
+
+    function self.none(tbl, condition)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(condition, "any", 2, false)
+
+      condition = assure_equality_function(condition)
+
+      return table.n_filter(tbl, condition) == nil
+    end
+
+    function self.one(tbl, condition)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(condition, "any", 2, false)
+
+      condition = assure_equality_function(condition)
+
+      return table.n_filter(tbl, condition) ~= nil and #table.n_filter(tbl, condition) == 1
+    end
+
+    function self.count(tbl, condition)
+      ___.v.indexed(tbl, 1, false)
+      ___.v.type(condition, "any", 2, false)
+
+      condition = assure_equality_function(condition)
+
+      return #table.n_filter(tbl, condition)
+    end
+
+    function self.natural_sort(tble)
+      print("We here")
+      ___.v.indexed(tble, 1, false)
+
+      local sorted = {}
+      for i = 1, #tble do
+        sorted[i] = tble[i]
+      end
+      table.sort(sorted, ___.string.natural_compare)
+      return sorted
+    end
+
+    function self.sort(tbl, arg)
+      ___.v.indexed(tbl, 1, false)
+
+      if type (arg) == "function" then
+        table.sort(tbl, arg)
+      else
+        return self.natural_sort(tbl)
+      end
+    end
+
+  end,
+  valid = function(___, self)
+    return {
+      not_empty = function(value, argument_index, nil_allowed)
+        assert(type(value) == "table", "Invalid type to argument " ..
+          argument_index .. ". Expected table, got " .. type(value) .. " in\n" ..
+          ___.get_last_traceback_line())
+        if nil_allowed and value == nil then
+          return
+        end
+
+        local last = ___.get_last_traceback_line()
+        assert(not table.is_empty(value), "Invalid value to argument " ..
+          argument_index .. ". Expected non-empty in\n" .. last)
+      end,
+
+      n_uniform = function(value, expected_type, argument_index, nil_allowed)
+        if nil_allowed and value == nil then
+          return
+        end
+
+        local last = ___.get_last_traceback_line()
+        assert(self.n_uniform(value, expected_type),
+          "Invalid type to argument " .. argument_index .. ". Expected an " ..
+          "indexed table of " .. expected_type .. " in\n" .. last)
+      end,
+      indexed = function(value, argument_index, nil_allowed)
+        if nil_allowed and value == nil then
+          return
+        end
+
+        local last = ___.get_last_traceback_line()
+        assert(self.indexed(value), "Invalid value to argument " ..
+          argument_index .. ". Expected indexed table, got " .. type(value) ..
+          " in\n" .. last)
+      end,
+      associative = function(value, argument_index, nil_allowed)
+        if nil_allowed and value == nil then
+          return
+        end
+
+        local last = ___.get_last_traceback_line()
+
+        assert(self.associative(value),
+          "Invalid value to argument " .. argument_index .. ". Expected " ..
+          "associative table, got " .. type(value) .. " in\n" .. last)
+      end,
+      object = function(value, argument_index, nil_allowed)
+        if nil_allowed and value == nil then
+          return
+        end
+
+        local last = ___.get_last_traceback_line()
+        assert(self.object(value), "Invalid value to argument " ..
+          argument_index .. ". Expected object, got " .. type(value) ..
+          " in\n" .. last)
+      end,
+      option = function(value, options, argument_index)
+        ___.v.type(value, "any", argument_index, false)
+        ___.v.indexed(options, argument_index, false)
+        ___.v.type(argument_index, "number", 3, false)
+
+        local last = ___.get_last_traceback_line()
+        assert(table.index_of(options, value) ~= nil, "Invalid value to " ..
+          "argument " .. argument_index .. ". Expected one of " ..
+          table.concat(options, ", ") .. ", got " .. value .. " in\n" .. last)
+      end
+    }
+  end,
+})


### PR DESCRIPTION
## Summary

Adds a curated set of 4 representative source files per parser type as test fixtures for validating the Lua and C parsers:

- **`examples/source/lua/`** — `string.lua`, `date.lua`, `table.lua`, `func.lua` (updated from meta definitions to implementations)
- **`examples/source/lua-library-source/`** — same 4 files as reference library variants (new meta definitions)
- **`examples/chokidar-as-cli/src/`** — `string.c`, `function.c`, `data.c`, `numbers.c` (new C function declarations)
- **`examples/source/lpc/data.c`** — minor annotation update adding `@return {void}` to `data_write`

The same 4 filenames are used across the Lua directories to ensure reproducibility when testing the same parser logic under different source contexts (standalone vs. library source). Files were chosen to cover a range of documentation patterns: simple utilities, date/time functions with rich annotations, collection utilities, and functional patterns.

## Test plan

- [ ] Run BeDoc against `examples/source/lua/` and verify Lua parser produces output
- [ ] Run BeDoc against `examples/source/lua-library-source/` and confirm same parser logic applies  
- [ ] Run BeDoc against `examples/chokidar-as-cli/src/` and verify C parser produces output

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 4 representative source files per parser type as test fixtures for validating BeDoc's Lua and C parsers: Lua implementations in `examples/source/lua/`, matching meta-definitions in `examples/source/lua-library-source/`, C declarations in `examples/chokidar-as-cli/src/`, and a minor `@return {void}` annotation to `examples/source/lpc/data.c`.

- The C fixture files are clean and well-documented.
- The Lua implementation files (`string.lua`, `table.lua`, `func.lua`) carry several runtime bugs identified in this and prior review rounds, including undefined variables, wrong module path references, and debug prints left in.
- `repeater` in `func.lua` has the same vararg-dropping issue as `delay`: `tempTimer` discards extra args, so all repetitions after the first call `func` with no arguments.
- The `shms` example in `lua-library-source/date.lua` has a digit transposition (`6453` vs `6543`) that makes the expected output incorrect.

<h3>Confidence Score: 3/5</h3>

The Lua implementation files have multiple confirmed runtime defects; the C fixture files and meta-definition stubs are safe.

The `func.lua` `repeater` function silently drops arguments on every timer-fired repetition, and several functions in `table.lua` and `string.lua` will error at runtime (already catalogued in earlier rounds). The C fixtures and `@meta` stubs are correct and carry no risk. The Lua implementation files need another pass before the full fixture set is reliable.

examples/source/lua/func.lua, examples/source/lua/table.lua, examples/source/lua/string.lua, and examples/source/lua-library-source/date.lua

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aexamples%2Fsource%2Flua-library-source%2Fdate.lua%3A22-23%0AThe%20second%20example%20call%20uses%20%606453%60%20but%20the%20expected%20output%20%60%221h%2049m%203s%22%60%20is%20correct%20only%20for%20%606543%60.%20For%20%606453%60%20the%20result%20would%20be%20%60%221h%2047m%2033s%22%60%20%281h%20%3D%203600%20s%2C%2047m%20%3D%202820%20s%2C%2033s%20%E2%86%92%20total%206453%20s%29.%20The%20digit%20transposition%20is%20easy%20to%20miss%3B%20fixing%20it%20to%20%606543%60%20keeps%20both%20examples%20consistent%20with%20each%20other.%0A%0A%60%60%60suggestion%0A%20%20---date.shms%286543%2C%20true%29%0A%20%20-----%20%221h%2049m%203s%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aexamples%2Fsource%2Flua%2Ffunc.lua%3A33-49%0A**%60repeater%60%20drops%20arguments%20after%20the%20first%20invocation**%0A%0AMudlet's%20%60tempTimer%60%20does%20not%20forward%20extra%20arguments%20to%20its%20callback.%20%60tempTimer%28interval%2C%20_repeat%2C%20...%29%60%20registers%20%60_repeat%60%20to%20fire%20later%2C%20but%20discards%20the%20varargs%20entirely%20%E2%80%94%20so%20on%20the%20second%20and%20all%20subsequent%20repetitions%2C%20%60_repeat%28%29%60%20is%20called%20with%20no%20arguments%20and%20%60func%28...%29%60%20receives%20nothing.%20Only%20the%20initial%20%60_repeat%28...%29%60%20call%20on%20line%2049%20passes%20the%20correct%20args.%20The%20fix%20is%20the%20same%20pattern%20as%20%60delay%60%3A%20capture%20%60local%20args%20%3D%20%7B...%7D%60%20before%20the%20inner%20function%20and%20call%20%60func%28table.unpack%28args%29%29%60%20inside%20%60_repeat%60.%0A%0A&repo=gesslar%2Fbedoc&pr=490&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (15): Last reviewed commit: ["test: add Lua source test fixtures for p..."](https://github.com/gesslar/bedoc/commit/7f9df5e3951c4840c40d96da278ae9be9bc22907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31709980)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->