### PR TITLE
Bump to version 2.1.0 - refactor config resolution and CLIOutput construction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/bedoc",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/bedoc",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Unlicense",
       "dependencies": {
         "@gesslar/actioneer": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/bedoc",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Pluggable documentation engine for any language and format",
   "publisher": "gesslar",
   "author": "gesslar",

--- a/src/BeDoc.js
+++ b/src/BeDoc.js
@@ -69,7 +69,7 @@ export default class BeDoc {
     config, options, source, basePath, glog, validateBeDocSchema, cliOutput
   }) {
     const resolved = config ?? await BeDoc.resolveConfig({options, source})
-    const base = basePath ?? options?.basePath
+    const base = basePath ?? resolved.basePath ?? options?.basePath
 
     const bedoc = new this({basePath: base, glog, cliOutput})
 

--- a/src/BeDoc.js
+++ b/src/BeDoc.js
@@ -7,7 +7,7 @@ import Conveyor from "./Conveyor.js"
 import Discovery from "./Discovery.js"
 
 /**
- * @import {FileObject, Glog} from "@gesslar/toolkit"
+ * @import {DirectoryObject, FileObject, Glog} from "@gesslar/toolkit"
  */
 
 export default class BeDoc {
@@ -30,20 +30,50 @@ export default class BeDoc {
   }
 
   /**
-   * Create a new instance of BeDoc.
+   * Resolve and validate configuration from all sources (CLI, environment,
+   * package.json, config file). This runs independently of any BeDoc instance
+   * so the resulting config object can be built first and shared with other
+   * consumers (e.g. CLIOutput) before a BeDoc instance exists.
    *
    * @param {object} args
-   * @param {object} args.options - The options passed into BeDoc
+   * @param {object} args.options - The raw options (with sources) to resolve
    * @param {string} args.source - The environment BeDoc is running in
+   * @returns {Promise<object>} The validated configuration object
+   */
+  static async resolveConfig({options, source}) {
+    const config = new Configuration()
+
+    return await config.validate({options, source})
+  }
+
+  /**
+   * Create a new instance of BeDoc.
+   *
+   * Configuration may be supplied pre-resolved (via {@link resolveConfig}) when
+   * a caller needs the config object before the instance exists — e.g. the CLI
+   * resolves it first to share with CLIOutput. Otherwise pass raw `options` and
+   * `source` and BeDoc resolves them itself, so any environment can construct a
+   * BeDoc in a single call.
+   *
+   * @param {object} args
+   * @param {object} [args.config] - Pre-validated configuration (see resolveConfig)
+   * @param {object} [args.options] - Raw options to resolve, if config is absent
+   * @param {string} [args.source] - The environment BeDoc is running in
+   * @param {DirectoryObject} [args.basePath] - The project base path
    * @param {Glog} args.glog - The Glog logger instance
+   * @param {Function} args.validateBeDocSchema - The action schema validator
+   * @param {object} args.cliOutput - The CLI output instance
    * @returns {Promise<BeDoc>} A new instance of BeDoc
    */
-  static async new({options, source, glog, validateBeDocSchema, cliOutput}) {
-    const {basePath} = options
+  static async new({
+    config, options, source, basePath, glog, validateBeDocSchema, cliOutput
+  }) {
+    const resolved = config ?? await BeDoc.resolveConfig({options, source})
+    const base = basePath ?? options?.basePath
 
-    const bedoc = new this({basePath, glog, cliOutput})
+    const bedoc = new this({basePath: base, glog, cliOutput})
 
-    await bedoc.#configure({options, source, glog, validateBeDocSchema})
+    bedoc.#configure({config: resolved, glog, validateBeDocSchema})
 
     const discovered = await bedoc.#discover()
 
@@ -60,29 +90,27 @@ export default class BeDoc {
   }
 
   /**
-   * Validate configuration and store as options.
+   * Apply validated configuration to this instance.
    *
-   * @param {object} options - The raw options passed into BeDoc
-   * @param {string} source - The environment BeDoc is running in
+   * @param {object} config - The validated configuration object
+   * @param {Glog} glog - The Glog logger instance
+   * @param {Function} validateBeDocSchema - The action schema validator
    */
-  async #configure({options, source, glog, validateBeDocSchema}) {
+  #configure({config, glog, validateBeDocSchema}) {
     this.#glog = glog
     this.#validateBeDocSchema = validateBeDocSchema
 
-    const config = new Configuration()
-    const validConfig = await config.validate({options, source})
-
-    if(validConfig.debug && validConfig.debugLevel > 0)
-      glog.withLogLevel(validConfig.debugLevel)
+    if(config.debug && config.debugLevel > 0)
+      glog.withLogLevel(config.debugLevel)
     else
       glog.withLogLevel(0)
 
-    if(validConfig.status === "error")
-      throw Tantrum.new("BeDoc configuration failed", validConfig.errors)
+    if(config.status === "error")
+      throw Tantrum.new("BeDoc configuration failed", config.errors)
 
-    glog.debug("Creating new BeDoc instance with options: `%o`", 4, validConfig)
+    glog.debug("Creating new BeDoc instance with options: `%o`", 4, config)
 
-    this.#options = validConfig
+    this.#options = config
   }
 
   /**

--- a/src/CLIOutput.js
+++ b/src/CLIOutput.js
@@ -66,9 +66,9 @@ export default class CLIOutput  {
    */
   #files = new Map()
 
-  constructor({basePath, terse = false}) {
+  constructor({basePath, config}) {
     this.#basePath = basePath
-    this.#terse = terse
+    this.#terse = Boolean(config.terse)
 
     Notify.on("conveyor-start", this.#conveyorStart)
     Notify.on("update-data", this.#updateData)

--- a/src/CLIOutput.js
+++ b/src/CLIOutput.js
@@ -66,8 +66,8 @@ export default class CLIOutput  {
    */
   #files = new Map()
 
-  constructor({basePath, config}) {
-    this.#basePath = basePath
+  constructor({config}) {
+    this.#basePath = config.basePath
     this.#terse = Boolean(config.terse)
 
     Notify.on("conveyor-start", this.#conveyorStart)

--- a/src/Configuration.js
+++ b/src/Configuration.js
@@ -142,6 +142,7 @@ export default class Configuration {
     return {
       status: "success",
       validated: true,
+      basePath: base,
       ...finalOptions,
     }
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -71,28 +71,37 @@ void (async() => {
       optionsWithSources[key] = element
     }
 
-    // Create core instance with validated config
+    // Resolve and validate configuration up front, before constructing
+    // anything that depends on it. Everything downstream — CLIOutput, BeDoc,
+    // the logger — consumes this single validated config object.
     const prjPath = new DirectoryObject()
-    const cliOutput = new CLIOutput({
-      basePath: prjPath,
-      terse: Boolean(options.terse),
-    })
     const prjPkJsonFile = new FileObject("package.json", prjPath)
     const prjPkjJson = await prjPkJsonFile.loadData()
     const pkjBedoc = prjPkjJson?.bedoc ?? {}
+
+    const config = await BeDoc.resolveConfig({
+      options: {
+        ...optionsWithSources,
+        basePath: prjPath,
+        project: pkjBedoc,
+      },
+      source: Environment.CLI,
+    })
+
+    const cliOutput = new CLIOutput({
+      basePath: prjPath,
+      config,
+    })
+
     const validateBeDocSchema = await loadSchemaValidator(thisPath)
 
     const bedoc = await BeDoc
       .new({
-        options: {
-          ...optionsWithSources,
-          basePath: prjPath,
-          project: pkjBedoc,
-        },
-        source: Environment.CLI,
+        config,
+        basePath: prjPath,
         glog,
         validateBeDocSchema,
-        cliOutput
+        cliOutput,
       })
 
     if(!(bedoc instanceof BeDoc)) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -88,17 +88,13 @@ void (async() => {
       source: Environment.CLI,
     })
 
-    const cliOutput = new CLIOutput({
-      basePath: prjPath,
-      config,
-    })
+    const cliOutput = new CLIOutput({config})
 
     const validateBeDocSchema = await loadSchemaValidator(thisPath)
 
     const bedoc = await BeDoc
       .new({
         config,
-        basePath: prjPath,
         glog,
         validateBeDocSchema,
         cliOutput,


### PR DESCRIPTION
## Introduce `resolveConfig` and pre-resolved config sharing

Adds a static `BeDoc.resolveConfig` method that validates configuration independently of any `BeDoc` instance. This allows the CLI to resolve configuration once up front and share the resulting object with all downstream consumers — `CLIOutput`, `BeDoc`, and the logger — rather than each constructing or receiving raw options separately.

`BeDoc.new` now accepts either a pre-resolved `config` object or raw `options`/`source`, falling back to calling `resolveConfig` itself when no pre-resolved config is provided. The internal `#configure` method is updated accordingly to apply an already-validated config rather than performing validation itself.

`CLIOutput` now receives the full `config` object instead of individual extracted values (replacing the `terse` boolean parameter).

The CLI startup sequence is updated to call `resolveConfig` first, then pass the result to both `CLIOutput` and `BeDoc.new`, eliminating duplicated option construction.

Bumps version to `2.1.0`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors BeDoc's configuration lifecycle by introducing `BeDoc.resolveConfig`, a static method that validates configuration independently of any instance. The CLI now resolves config once upfront and shares the resulting object with `CLIOutput`, `BeDoc`, and the logger instead of each receiving raw options separately.

- `BeDoc.new` accepts either a pre-resolved `config` or raw `options`/`source`, falling back to calling `resolveConfig` itself; the internal `#configure` method becomes a synchronous setter that applies an already-validated config rather than re-validating.
- `CLIOutput` now accepts the full `config` object (reading `config.basePath` and `config.terse`) instead of individual extracted values, and `Configuration.validate` now includes `basePath` in its return so pre-resolved configs always carry the path.
- The version is bumped to `2.1.0`.

<h3>Confidence Score: 5/5</h3>

The refactoring is safe to merge: config resolution is now a clean one-pass flow, the shared config object is always fully populated before any consumer touches it, and no existing call site is silently broken.

Config validation either throws or returns a well-formed success object, so every downstream consumer (CLIOutput, BeDoc, logger) is guaranteed a valid config. The #configure method correctly drops its async/await now that it no longer calls Configuration.validate. The basePath inclusion in the return value of Configuration.validate ensures that pre-resolved configs always carry the path, plugging the gap identified in the prior review cycle. No new logic errors were introduced.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["2.1.0"](https://github.com/gesslar/bedoc/commit/a07ed7ad3f583c4f473a6e8f44cb23b1717a5222) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36610153)</sub>

<!-- /greptile_comment -->