### PR TITLE
Bump to version 2.1.2 - exclude tsconfig.types.json from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ examples/
 **/*.tgz
 eslint.config.js
 jsconfig.json
+tsconfig.types.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/bedoc",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/bedoc",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "Unlicense",
       "dependencies": {
         "@gesslar/actioneer": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/bedoc",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Pluggable documentation engine for any language and format",
   "publisher": "gesslar",
   "author": "gesslar",


### PR DESCRIPTION
Bumps the package version to `2.1.2` and excludes `tsconfig.types.json` from the published npm package.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the package version from `2.1.1` to `2.1.2` and adds `tsconfig.types.json` to `.npmignore` to prevent it from being included in the published npm package.

- Version updated consistently across `package.json` and `package-lock.json`.
- `tsconfig.types.json` added to `.npmignore`, keeping the published package lean by excluding a build-time TypeScript config file that consumers don't need.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only changes are a patch version bump and excluding one TypeScript config file from the npm bundle.

The diff is minimal: a patch version increment applied consistently across `package.json` and `package-lock.json`, and a single-line addition to `.npmignore`. No logic, dependencies, or API surface is touched.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["2.1.2"](https://github.com/gesslar/bedoc/commit/29c5d849eab5b7ab9fa82c3be3eec7fb0c5b8dca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38905087)</sub>

<!-- /greptile_comment -->