### PR TITLE
Bump to version 2.1.3 - update @gesslar/actioneer to 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.2",
       "license": "Unlicense",
       "dependencies": {
-        "@gesslar/actioneer": "^3.1.0",
+        "@gesslar/actioneer": "^3.1.1",
         "@gesslar/colours": "^1.0.0",
         "@gesslar/negotiator": "^1.0.0",
         "@gesslar/toolkit": "^5.6.0",
@@ -174,12 +174,12 @@
       }
     },
     "node_modules/@gesslar/actioneer": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.1.0.tgz",
-      "integrity": "sha512-xSM9u09lABt70BtlbYnhR5cuAwQnl1+iH9A7au3HLMwgrPeb8UJjYVo1FlN+CZRKlZkWqfrcxYHAqZrdRyY7JA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@gesslar/actioneer/-/actioneer-3.1.1.tgz",
+      "integrity": "sha512-SCdzcxl3SbCW+GScIkewRIlhL6DY6L7DLdCjMA3Me8ovW9FIv/dbj+YY5BkAdQ4ZTndasHzxZewT69snc/GllQ==",
       "license": "0BSD",
       "dependencies": {
-        "@gesslar/toolkit": "^5.5.2"
+        "@gesslar/toolkit": "^5.6.0"
       },
       "engines": {
         "node": ">=24"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/bedoc",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/bedoc",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Unlicense",
       "dependencies": {
         "@gesslar/actioneer": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "major": "npm version major"
   },
   "dependencies": {
-    "@gesslar/actioneer": "^3.1.0",
+    "@gesslar/actioneer": "^3.1.1",
     "@gesslar/colours": "^1.0.0",
     "@gesslar/negotiator": "^1.0.0",
     "@gesslar/toolkit": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/bedoc",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Pluggable documentation engine for any language and format",
   "publisher": "gesslar",
   "author": "gesslar",


### PR DESCRIPTION
Bumps the package version to `2.1.3` and updates the `@gesslar/actioneer` dependency from `3.1.0` to `3.1.1`, which itself now requires `@gesslar/toolkit` `^5.6.0`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `@gesslar/bedoc` from `2.1.2` to `2.1.3` and updates the `@gesslar/actioneer` dependency from `3.1.0` to `3.1.1`.

- Both `package.json` and `package-lock.json` are updated consistently, with the version bump and the new `actioneer` resolved hash reflected correctly.
- The transitive `@gesslar/toolkit` requirement for `actioneer` moves from `^5.5.2` to `^5.6.0`, which aligns with the existing direct `toolkit` constraint already pinned at `^5.6.0` in `bedoc` — no version conflict introduced.

<h3>Confidence Score: 5/5</h3>

This is a routine patch-level dependency bump with no logic changes — safe to merge.

The only changes are version strings in package.json and the corresponding resolved hash/peer requirement updates in package-lock.json. Both files are internally consistent, and the new transitive @gesslar/toolkit ^5.6.0 requirement from actioneer matches the constraint already declared directly by this package, so no version drift or conflict is introduced.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["2.1.3"](https://github.com/gesslar/bedoc/commit/8076ac3acb90c1000fa9e82dd4a172f48a004e29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38907806)</sub>

<!-- /greptile_comment -->